### PR TITLE
Configure Quarto website skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.quarto/
+/_site/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,81 @@
+project:
+  type: website
+  output-dir: _site
+
+website:
+  title: "STT-1100 Introduction à la science des données"
+  sidebar:
+    style: "floating"
+    contents:
+      - text: "Accueil"
+        href: index.qmd
+      - section: "Modules"
+        contents:
+          - section: "Module 1"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 1 /1 - Plan d'apprentissage.qmd"
+              - text: "Aventure"
+                href: "Module 1 /1 - Aventure/Aventure 1.qmd"
+              - text: "Défi"
+                href: "Module 1 /1 - défi/1 - Défi Plongée en science des données.qmd"
+          - section: "Module 2"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 2/2 - Plan d'apprentissage.qmd"
+              - text: "Aventure"
+                href: "Module 2/2 - Aventure/Aventure 2.qmd"
+              - text: "Défi"
+                href: "Module 2/2 - défi/2 - Défi.qmd"
+          - section: "Module 3"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 3/3 - Plan d'apprentissage.qmd"
+              - text: "Aventure"
+                href: "Module 3/3 - Aventure/Aventure 3.qmd"
+              - text: "Défi"
+                href: "Module 3/3 - défi/3 - Défi.qmd"
+          - section: "Module 4"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 4/4 - Plan d'apprentissage.qmd"
+              - text: "Aventure"
+                href: "Module 4/Aventure/Aventure 4.qmd"
+          - section: "Module 5"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 5/plan d'apprentissage module 5.qmd"
+              - text: "Aventure"
+                href: "Module 5/aventure/Aventure 5.qmd"
+          - section: "Module 6"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 6/Plan d'apprentissage module 6.qmd"
+              - text: "Aventure"
+                href: "Module 6/Aventure/Aventure 6.qmd"
+          - section: "Module 7"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 7/Plan d'apprentissage module 7.qmd"
+              - text: "Aventure"
+                href: "Module 7/Aventure/Aventure 7.qmd"
+          - section: "Module 8"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 8/Plan d'apprentissage module 8.qmd"
+              - text: "Aventure"
+                href: "Module 8/Aventure/Aventure 8.qmd"
+          - section: "Module 9"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 9/Plan d'apprentissage module 9.qmd"
+              - text: "Aventure"
+                href: "Module 9/Aventure/Aventure 9.qmd"
+          - section: "Module 10"
+            contents:
+              - text: "Plan d'apprentissage"
+                href: "Module 10/Plan d'apprentissage module 10.qmd"
+              - text: "Aventure"
+                href: "Module 10/Aventure/Aventure 10.qmd"
+      - text: "Matériel de référence"
+        href: references.qmd

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,11 @@
+---
+title: "Accueil"
+format:
+  html:
+    css: css/base_css.css
+---
+
+# Accueil
+
+Contenu à venir.
+

--- a/references.qmd
+++ b/references.qmd
@@ -1,0 +1,11 @@
+---
+title: "Matériel de référence"
+format:
+  html:
+    css: css/base_css.css
+---
+
+# Matériel de référence
+
+Contenu à ajouter.
+


### PR DESCRIPTION
## Summary
- setup Quarto website configuration with floating sidebar and module navigation
- add placeholder home and reference pages using existing CSS styling
- ignore Quarto build artifacts in version control

## Testing
- `quarto render --no-execute` *(fails: Unable to locate an installed version of R)*
- `quarto render index.qmd references.qmd --no-execute`


------
https://chatgpt.com/codex/tasks/task_e_689490c679fc8322b64be408d2bbb710