### PR TITLE
Harmonise modules et objectifs

### DIFF
--- a/Module 1 /1 - Plan d'apprentissage.qmd
+++ b/Module 1 /1 - Plan d'apprentissage.qmd
@@ -16,19 +16,13 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de
 
--   Utiliser RStudio pour rédiger et exécuter du code R à l'aide de la console et de scripts.
-
--   Installer et charger des libraries.
-
--   Créer et manipuler des objets R, utiliser des conditions, utiliser des fonctions existantes, écrire des fonctions simples,
-
--   Rédiger le code R en suivant les conventions de style du tidyverse.
-
--   Vérifier si un jeu de données est propre (plus tard on va en rendre un au format propre)
-
--   Extraire une ligne, une colonne, ajouter une colonne, filtrer des données en utilisant une ou plusieurs conditions.
-
--   Rédiger un rapport simple dans Quarto, incluant du texte, des blocs de code, des titres de sections.
+- Utiliser RStudio pour rédiger et exécuter du code R à l’aide de la console et de scripts.
+- Installer et charger des librairies.
+- Créer et manipuler des objets R, utiliser des conditions, utiliser des fonctions existantes, écrire des fonctions simples.
+- Rédiger le code R en suivant les conventions de style du `tidyverse`.
+- Vérifier si un jeu de données est propre.
+- Extraire une ligne ou une colonne, ajouter une colonne, filtrer des données en utilisant une ou plusieurs conditions.
+- Rédiger un rapport simple dans Quarto, incluant du texte, des blocs de code, des titres de sections.
 
 # Lectures initiales
 
@@ -62,7 +56,7 @@ C’est une **référence incontournable**, accessible gratuitement en ligne et 
 
 Ce module est conçu pour vous offrir une introduction complète aux outils et concepts fondamentaux qui vous accompagneront tout au long de votre parcours en science des données.
 
-[Aventure du module 1](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1744873/page4737047/bloccontenu5035061/Aventure%201.html?identifiant=71aaec55633c07871f7fea3a620fadd2dc0cdf3e)
+[Aventure du module 1](1%20-%20Aventure/Aventure%201.qmd)
 
 # Défi
 

--- a/Module 10/Plan d'apprentissage module 10.qmd
+++ b/Module 10/Plan d'apprentissage module 10.qmd
@@ -15,12 +15,11 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de :
 
-* Nettoyer et analyser des données textuelles.
-* Construire un lexique de sentiment simple en français.
-* Visualiser les tendances lexicales et émotionnelles dans le temps.
-* Utiliser TF-IDF pour repérer les mots distinctifs.
-* Analyser des scores numériques liés à l'expérience étudiante.
-* Créer un tableau de bord interactif avec `flexdashboard` et `shiny`.
+- Nettoyer et analyser des données textuelles.
+- Construire un lexique de sentiment simple en français.
+- Visualiser les tendances lexicales et émotionnelles dans le temps.
+- Utiliser TF-IDF pour repérer les mots distinctifs.
+- Créer un tableau de bord interactif avec `flexdashboard` et `shiny`.
 
 # 📚 Lectures
 
@@ -34,7 +33,7 @@ Pour vous préparer, consultez les ressources suivantes :
 
 Vous êtes analyste d’affaires junior engagé par la Faculté des sciences et de génie de l’Université Laval. Votre mandat : analyser les commentaires anonymes des étudiant·es sur le cours STT-1100 et produire un tableau de bord interactif pour la direction du programme.
 
-👉 [Aventure 10 — Analyse de sentiment et tableau de bord](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1761145/page4781375/bloccontenu5092181/Aventure%2010.html?identifiant=c3b38685978291f6d48094750eee33b92964db65){target="\_blank"}
+👉 [Aventure 10 — Analyse de sentiment et tableau de bord](Aventure/Aventure%2010.qmd)
 
 # 💡 Défi — Tableau de bord déployé {.unnumbered}
 

--- a/Module 2/2 - Plan d'apprentissage.qmd
+++ b/Module 2/2 - Plan d'apprentissage.qmd
@@ -16,6 +16,14 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de:
 
+- Utiliser `GitHub` via `RStudio` pour clôner un dépôt et faire des commit et des push.
+- Lire un fichier `xls` dans `RStudio`.
+- Gérer et transformer des données numériques à l'aide de `dplyr` (`glimpse()`, `select()`, `mutate()`, `filter()`).
+- Calculer et interpréter des statistiques descriptives pour des variables numériques (moyenne, médiane, écart-type, variance, étendue, quantiles), incluant pour des sous-groupes de données.
+- Visualiser des variables numériques avec `ggplot2` (histogramme, boîte à moustaches, nuage de points) et interpréter les graphiques obtenus.
+- Produire et interpréter des graphiques comparant la distribution de variables continues entre des groupes (histogrammes superposés, diagrammes en boîtes juxtaposés, densités empilées, visualisation en facettes).
+- Utiliser les options de `ggplot2` pour améliorer la qualité de graphiques (titres, légendes, axes lisibles, cohérence graphique, facettes).
+
 # Lectures initiales
 
 Comme le module 2 est étallé sur 2 semaines, il y a un peu plus de lecture, pour vous préparer à la première partie du module vous pouvez survoler les lectures et y revenir de facon plus précise en préparation de la partie 2.
@@ -51,7 +59,7 @@ Ce livre, également accessible gratuitement en ligne, propose une **approche mo
 
 # Aventure
 
-[Aventure 2](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1745410/page4738255/bloccontenu5036520/Aventure%202.html?identifiant=dd4c9d572c9504b55e6d29feed9e2a8721021d50)
+[Aventure 2](2%20-%20Aventure/Aventure%202.qmd)
 
 # Défi
 

--- a/Module 3/3 - Plan d'apprentissage.qmd
+++ b/Module 3/3 - Plan d'apprentissage.qmd
@@ -16,6 +16,12 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de
 
+- Manipuler des chaînes de caractères avec `stringr`.
+- Reconnaitre des motifs avec des expressions régulières.
+- Utiliser les expressions régulières pour sélectionner, manipuler et modifier des chaînes de caractères.
+- Calculer et interpréter des statistiques descriptives pour des variables catégoriques (tableaux de fréquences, proportions, incluant par groupes, tableau croisé).
+- Produire et interpréter des visualisations de variables catégoriques avec `ggplot2` (diagramme à bandes, en bâtons empilés, en bâtons empilés standardisé, en bâtons empilés groupés, en mosaïque, en secteurs et en gaufre).
+
 # Lectures initiales
 
 ## 📘 Lectures à faire avant l’aventure
@@ -33,7 +39,7 @@ Prenez le temps de parcourir ces deux ressources. Elles vous seront utiles pour 
 
 # Aventure
 
-[Aventure 3](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1745726/page4738675/bloccontenu5037472/Aventure%203.html?identifiant=0278d4344021ebee7ae2a5e2f025152db9866727)
+[Aventure 3](3%20-%20Aventure/Aventure%203.qmd)
 
 # Défi
 

--- a/Module 4/4 - Plan d'apprentissage.qmd
+++ b/Module 4/4 - Plan d'apprentissage.qmd
@@ -16,7 +16,10 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de
 
-
+- Importer des données de différents formats (`txt`, `csv`, `excel`, `json`).
+- Nettoyer et recoder des données pour assurer leur qualité.
+- Utiliser les librairies `forcats` et `stringr` pour manipuler des facteurs et des chaînes de caractères.
+- Créer et utiliser des listes.
 
 # Lectures initiales
 
@@ -47,7 +50,7 @@ Dans ce module, nous allons explorer les concepts de base de l'importation et du
 
 # Aventure
 
-[Aventure 4](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1747262/page4742827/bloccontenu5043393/Aventure%204.html?identifiant=afa8069a82b693eba79bcfb3092d453ef69c140a){target="_blank"}
+[Aventure 4](Aventure/Aventure%204.qmd)
 
 # Défi
 

--- a/Module 5/plan d'apprentissage module 5.qmd
+++ b/Module 5/plan d'apprentissage module 5.qmd
@@ -14,9 +14,14 @@ editor: visual
 
 # 🎯 Objectifs du module
 
+À la fin de ce module, vous devriez être capable de :
 
+- Gérer et analyser des variables temporelles à l’aide de `lubridate`.
+- Étudier la relation entre deux variables à l’aide de graphiques et de statistiques descriptives, notamment à l’aide du coefficient de corrélation.
+- Calculer et interpréter la corrélation entre deux variables numériques.
+- Rédiger un rapport d’analyse exploratoire des données (EDA) mettant en évidence des tendances et des motifs dans les données.
 
-# 📚 Lectures 
+# 📚 Lectures
 
 Dans ce module, nous allons explorer les concepts de base de l'analyse exploratoire des données (EDA) et de la manipulation des dates et heures. Voici quelques lectures initiales pour vous préparer :
 
@@ -39,7 +44,7 @@ Dans le libre **IMS**:
 
 # Aventure 
 
-[Aventure 5](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1747528/page4742999/bloccontenu5043572/Aventure%205.html?identifiant=d96cd9dbb1d47b5de3ca3ceaff7e32ca9a9d05c8){target="_blank"}
+[Aventure 5](aventure/Aventure%205.qmd)
 
 # 🎯 Défi — Analyser les retards pour soutenir les décisions
 

--- a/Module 6/Plan d'apprentissage module 6.qmd
+++ b/Module 6/Plan d'apprentissage module 6.qmd
@@ -16,6 +16,11 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de :
 
+- Collaborer efficacement sur des projets de science des données en utilisant `GitHub`.
+- Assurer la reproductibilité des analyses avec `Quarto`.
+- Fusionner et gérer plusieurs jeux de données.
+- Expliquer le cycle de vie des données et les principes de `DataOps`.
+
 # 📚 Lectures
 
 Dans ce module, nous allons explorer les concepts de base de la collaboration et de la reproductibilité dans GitHub, ainsi que l'utilisation de Quarto pour créer des rapports dynamiques. Voici quelques lectures initiales pour vous préparer :
@@ -28,7 +33,7 @@ Dans ce module, nous allons explorer les concepts de base de la collaboration et
 
 # Aventure
 
-[Aventure 6](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1749495/page4748069/bloccontenu5051685/Aventure%206.html?identifiant=dfe7c3447de40434caa452a70789d5037ecc5ca5){target="_blank"}
+[Aventure 6](Aventure/Aventure%206.qmd)
 
 # 🎯 Défi — Revue croisée des journaux de bord {.unnumbered}
 

--- a/Module 7/Plan d'apprentissage module 7.qmd
+++ b/Module 7/Plan d'apprentissage module 7.qmd
@@ -16,6 +16,15 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de :
 
+- Identifier des problèmes éthiques dans une visualisation.
+- Anonymiser correctement des données.
+- Appliquer les bonnes pratiques de visualisation pour représenter les données de manière claire et honnête.
+- Identifier et éviter les biais de présentation des données.
+- Comprendre les enjeux éthiques et de confidentialité liés à la science des données.
+- Mettre en place des mesures de protection et de sécurisation des données sensibles.
+- Expliquer les principes CRAP.
+- Expliquer les principes FAIR.
+
 # 📚 Lectures
 
 Pour vous préparer, consultez les ressources suivantes :
@@ -27,7 +36,7 @@ Pour vous préparer, consultez les ressources suivantes :
 
 Vous incarnerez un·e **expert·e en éthique des données** et serez chargé·e d’évaluer un rapport problématique.\
 Lien vers l’aventure :\
-👉 [Aventure 7 — Visualisation, éthique et sécurisation des données](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1760817/page4780481/bloccontenu5091038/Aventure%207.html?identifiant=0d4718cb5f8b3d9d167016aacebb13440d5ce5cf){target="_blank"}
+👉 [Aventure 7 — Visualisation, éthique et sécurisation des données](Aventure/Aventure%207.qmd)
 
 # 💡 Défi — Analyse éthique et visualisation responsable {.unnumbered}
 

--- a/Module 8/Plan d'apprentissage module 8.qmd
+++ b/Module 8/Plan d'apprentissage module 8.qmd
@@ -16,9 +16,8 @@ editor: visual
 À la fin de ce module, vous devriez être capable de :
 
 - Extraire des données textuelles d’une page web en utilisant `rvest`.
-- Créer une fonction R réutilisable pour automatiser le scraping.
-- Mettre en œuvre une boucle `for` pour répéter une tâche sur plusieurs pages.
-- Adopter une posture éthique face à la collecte automatisée de données en ligne.
+- Automatiser des tâches répétitives à l'aide de boucles et de fonctions en R.
+- Identifier les aspects éthiques liés à la collecte automatisée de données en ligne.
 
 # 📚 Lectures
 
@@ -31,7 +30,7 @@ Pour vous préparer, consultez les ressources suivantes :
 
 Vous incarnez un·e **consultant·e freelance** engagé·e pour développer une fonction d’extraction automatisée de métadonnées à partir du portail Données Québec.\
 Lien vers l’aventure :\
-👉 [Aventure 8 — Données ouvertes du Québec](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1761141/page4781367/bloccontenu5092173/Aventure%208.html?identifiant=bf6dacc96b5f09c35a7f5906c3cd5f3b2443b2fc){target="_blank"}
+👉 [Aventure 8 — Données ouvertes du Québec](Aventure/Aventure%208.qmd)
 
 # 💡 Défi — Fonction de scraping {.unnumbered}
 

--- a/Module 9/Plan d'apprentissage module 9.qmd
+++ b/Module 9/Plan d'apprentissage module 9.qmd
@@ -15,6 +15,10 @@ editor: visual
 
 À la fin de ce module, vous devriez être capable de :
 
+- Ajuster et interpréter un modèle de régression linéaire simple.
+- Utiliser un modèle de régression linéaire simple pour obtenir des prédictions.
+- Ajuster et interpréter un modèle de régression linéaire multiple.
+- Reconnaître et discuter des biais potentiels, notamment ceux liés à la discrimination, dans les données ou les modèles.
 
 # 📚 Lectures
 
@@ -29,7 +33,7 @@ Pour vous préparer, consultez les ressources suivantes :
 
 Vous incarnez un·e **scientifique de données** au sein du Ministère de l'Éducation du Québec. Votre mandat est double : construire un modèle prédictif à partir de données d’écoles primaires, puis explorer un jeu de données fictif pour y détecter des biais.
 
-👉 [Aventure 9 — Prédiction et biais algorithmiques](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1761142/page4781370/bloccontenu5092177/Aventure%209.html?identifiant=49fe010f19810d0a54003edf599744d4c9014843){target="_blank"}
+👉 [Aventure 9 — Prédiction et biais algorithmiques](Aventure/Aventure%209.qmd)
 
 # 💡 Défi — Capsule vidéo {.unnumbered}
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -11,7 +11,7 @@ website:
         href: index.qmd
       - section: "Modules"
         contents:
-          - section: "Module 1"
+          - section: "1 - Plongée en science des données"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 1 /1 - Plan d'apprentissage.qmd"
@@ -19,7 +19,7 @@ website:
                 href: "Module 1 /1 - Aventure/Aventure 1.qmd"
               - text: "Défi"
                 href: "Module 1 /1 - défi/1 - Défi Plongée en science des données.qmd"
-          - section: "Module 2"
+          - section: "2 - GitHub et visualisation de données"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 2/2 - Plan d'apprentissage.qmd"
@@ -27,7 +27,7 @@ website:
                 href: "Module 2/2 - Aventure/Aventure 2.qmd"
               - text: "Défi"
                 href: "Module 2/2 - défi/2 - Défi.qmd"
-          - section: "Module 3"
+          - section: "3 - Les catégories sous toutes leurs formes"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 3/3 - Plan d'apprentissage.qmd"
@@ -35,43 +35,43 @@ website:
                 href: "Module 3/3 - Aventure/Aventure 3.qmd"
               - text: "Défi"
                 href: "Module 3/3 - défi/3 - Défi.qmd"
-          - section: "Module 4"
+          - section: "4 - Facteurs et nettoyage de données"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 4/4 - Plan d'apprentissage.qmd"
               - text: "Aventure"
                 href: "Module 4/Aventure/Aventure 4.qmd"
-          - section: "Module 5"
+          - section: "5 - Explorer et comprendre les relations entre les variables"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 5/plan d'apprentissage module 5.qmd"
               - text: "Aventure"
                 href: "Module 5/aventure/Aventure 5.qmd"
-          - section: "Module 6"
+          - section: "6 - Collaboration et reproductibilité dans GitHub"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 6/Plan d'apprentissage module 6.qmd"
               - text: "Aventure"
                 href: "Module 6/Aventure/Aventure 6.qmd"
-          - section: "Module 7"
+          - section: "7 - Visualisation, éthique et sécurisation des données"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 7/Plan d'apprentissage module 7.qmd"
               - text: "Aventure"
                 href: "Module 7/Aventure/Aventure 7.qmd"
-          - section: "Module 8"
+          - section: "8 - Automatisation et exploration du web"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 8/Plan d'apprentissage module 8.qmd"
               - text: "Aventure"
                 href: "Module 8/Aventure/Aventure 8.qmd"
-          - section: "Module 9"
+          - section: "9 - Prédiction et biais"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 9/Plan d'apprentissage module 9.qmd"
               - text: "Aventure"
                 href: "Module 9/Aventure/Aventure 9.qmd"
-          - section: "Module 10"
+          - section: "10 - Au-delà des données : texte et tableau de bord"
             contents:
               - text: "Plan d'apprentissage"
                 href: "Module 10/Plan d'apprentissage module 10.qmd"

--- a/index.qmd
+++ b/index.qmd
@@ -5,6 +5,14 @@ format:
     css: css/base_css.css
 ---
 
-# Accueil
+# STT-1100 Introduction à la science des données
 
-Contenu à venir.
+Bienvenue sur le site du cours **STT-1100 Introduction à la science des données**. Vous y trouverez les plans d'apprentissage, les aventures et le matériel de référence pour chaque module.
+
+## Objectifs généraux du cours
+
+1. Maîtriser les outils et techniques fondamentaux de la science des données : les étudiants apprendront à utiliser `RStudio`, `GitHub` et `Quarto` pour manipuler, analyser et présenter des données de manière efficace.
+2. Développer des compétences en gestion et en visualisation de données : les participants seront formés à importer, nettoyer, transformer et visualiser divers types de données, en mettant l'accent sur les bonnes pratiques et l'éthique.
+3. Appliquer des méthodes statistiques et algorithmiques pour l'analyse de données : les étudiants acquerront des compétences en statistiques descriptives, en analyse exploratoire et en modélisation prédictive, tout en étant sensibilisés aux biais algorithmiques.
+4. Favoriser la collaboration et la reproductibilité dans les projets de science des données : le cours encouragera le travail en équipe, l'utilisation de systèmes de contrôle de version et l'adoption de pratiques garantissant la reproductibilité des analyses.
+


### PR DESCRIPTION
## Summary
- rename sidebar modules with descriptive titles
- update learning plans with new objectives and internal adventure links
- add course overview on home page

## Testing
- `quarto check`

------
https://chatgpt.com/codex/tasks/task_e_68949c4589f4832282b4a0c86269fb19