### PR TITLE
ci: publish Quarto to gh-pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish Quarto site to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: write   # nécessaire pour pousser sur gh-pages
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: "stable"
+
+      # (Optionnel) Installe TinyTeX si le projet rend des PDF
+      # - name: Setup TinyTeX
+      #   uses: r-lib/actions/setup-tinytex@v2
+
+      - name: Render site
+        run: quarto render
+
+      - name: Publish to gh-pages
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/.quarto/
-/_site/
+_site/
+.quarto/
+.Rproj.user/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# STT-1100 Notes de cours
+
+Ce dépôt contient un site Quarto pour les notes de cours du cours STT-1100.
+
+## Déploiement (GitHub Pages)
+Ce dépôt utilise GitHub Actions pour rendre et publier le site Quarto vers la branche `gh-pages`.
+- Chaque push sur `main` déclenche la génération (`quarto render`) puis la publication.
+- La branche publiée est `gh-pages` (racine).
+- Si la page n’apparaît pas, vérifiez dans **Settings → Pages** que la source est **Deploy from a branch** avec **Branch: gh-pages / folder: /** (ou **GitHub Actions**, selon votre configuration).


### PR DESCRIPTION
## Summary
- configure workflow to render Quarto site and publish to gh-pages
- ignore Quarto build artifacts and add deployment docs

## Testing
- `quarto render` *(fails: command not found: quarto)*

------
https://chatgpt.com/codex/tasks/task_e_689dec5406d48322b212ccacd968326e