### PR TITLE
Add English version of course site and bilingual switching improvements

### DIFF
--- a/en/_quarto.yml
+++ b/en/_quarto.yml
@@ -1,0 +1,90 @@
+project:
+  type: website
+  output-dir: ../docs/en
+
+website:
+  title: "STT-1100 Introduction to Data Science"
+  sidebar:
+    style: "floating"
+    contents:
+      - text: "Home"
+        href: index.qmd
+      - section: "Modules"
+        contents:
+          - section: "1 - Data science dive"
+            contents:
+              - text: "Learning plan"
+                href: "module_01/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_01/aventure.qmd"
+              - text: "Challenge"
+                href: "module_01/defi.qmd"
+              - text: "Corrected exercises"
+                href: "module_01/exercices_corriges.qmd"
+          - section: "2 - GitHub and data visualization"
+            contents:
+              - text: "Learning plan"
+                href: "module_02/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_02/aventure.qmd"
+          - section: "3 - Categories in all their forms"
+            contents:
+              - text: "Learning plan"
+                href: "module_03/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_03/aventure.qmd"
+          - section: "4 - Factors and data cleaning"
+            contents:
+              - text: "Learning plan"
+                href: "module_04/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_04/aventure.qmd"
+          - section: "5 - Explore and understand relationships between variables"
+            contents:
+              - text: "Learning plan"
+                href: "module_05/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_05/aventure.qmd"
+              - text: "Exercises"
+                href: "module_05/exercices.qmd"
+          - section: "6 - Collaboration and reproducibility in GitHub"
+            contents:
+              - text: "Learning plan"
+                href: "module_06/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_06/aventure.qmd"
+          - section: "7 - Visualization, ethics and data security"
+            contents:
+              - text: "Learning plan"
+                href: "module_07/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_07/aventure.qmd"
+              - text: "Initial COVID-19 analysis"
+                href: "module_07/analyse_covid.qmd"
+          - section: "8 - Automation and web exploration"
+            contents:
+              - text: "Learning plan"
+                href: "module_08/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_08/aventure.qmd"
+          - section: "9 - Prediction and bias"
+            contents:
+              - text: "Learning plan"
+                href: "module_09/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_09/aventure.qmd"
+          - section: "10 - Beyond data: text and dashboard"
+            contents:
+              - text: "Learning plan"
+                href: "module_10/plan_apprentissage.qmd"
+              - text: "Adventure"
+                href: "module_10/aventure.qmd"
+          - section: "Session project"
+            contents:
+              - text: "Project statement"
+                href: "projet_session/enonce_projet.qmd"
+      - text: "Reference material"
+        href: references.qmd
+format:
+  html:
+    include-after-body: ../toggle-sidebar.html

--- a/en/autre_materiel/Aide mémoire Rstudio et Github.qmd
+++ b/en/autre_materiel/Aide mémoire Rstudio et Github.qmd
@@ -1,0 +1,101 @@
+---
+title: "Cheat sheet — Clone a GitHub project into RStudio"
+format:
+  html:
+    toc: true
+    toc-depth: 2
+    theme: cosmo
+    highlight-style: github
+    embed-resources: true
+    code-tools: true
+    page-layout: full
+---
+
+
+## 🧠 Preparation
+
+✅ You must have installed:
+
+-R
+-RStudio
+- Git (check with `git --version` in terminal)
+- A GitHub account
+
+💡 **Optional but recommended**: Link RStudio to your GitHub account with an SSH key.
+(Remember to **never** use your GitHub password directly)
+
+---
+
+## 🔗 Find GitHub project link
+
+1. Go to the page of the GitHub repository you want to clone.
+2. Click on the green **`<> Code`** button.
+3. Choose the **SSH** or **HTTPS** tab, then copy the displayed link.
+
+> Example:
+> - SSH: `git@github.com:UserName/project-name.git`
+> - HTTPS: `https://github.com/UserName/project-name.git`
+
+---
+
+## 💻 Clone in RStudio
+
+1. Open **RStudio**
+2. Go to **File > New Project**
+3. Choose **Version Control**
+4. Select **Git**
+5. Paste the copied link into the **Repository URL** field
+6. Choose a local folder to save the project
+7. Click on **Create Project**
+
+🎉 It’s done! You can start working in your new RStudio project.
+
+---
+
+## ⚠️ Tip: GitHub Authentication Error
+
+If you get this error:
+
+```
+fatal: Authentication failed
+remote: Support for password authentication was removed...
+```
+
+This means that you used **HTTPS without a personal token (PAT)**.
+
+### Two solutions:
+
+- Generate a **Personal Access Token** (PAT) on GitHub, then use it as a password.
+- Or configure **SSH**, which is simpler in the long run.
+
+---
+
+## 🔐 Bonus: Configure SSH with GitHub (recommended)
+
+```bash
+#1. Generate an SSH key (if not already done)
+ssh-keygen -t ed25519 -C "ton-email@example.com"
+
+#2. Add your SSH key to the agent
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+
+#3. Copy your public key
+cat ~/.ssh/id_ed25519.pub
+```
+
+Then paste this key into **GitHub > Settings > SSH and GPG keys > New SSH key**.
+
+👉 Details: <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>
+
+---
+
+## 📎 Useful resources
+
+- [RStudio GitHub Guide (RStudio Support)](https://support.posit.co/hc/en-us/articles/200532077)
+- [Create a GitHub token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+- [Configure SSH GitHub (Official)](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+
+---
+
+Happy programming! 🧪💻

--- a/en/autre_materiel/Cheat sheet/stt1100_cheatsheet_mod.qmd
+++ b/en/autre_materiel/Cheat sheet/stt1100_cheatsheet_mod.qmd
@@ -1,0 +1,127 @@
+---
+title: "STT-1100 — Checklist sheet"
+author: "Laval University"
+format:
+  pdf:
+    pagetemplate: cheatsheet
+    keep-tex: true
+    geometry: "landscape"
+fontsize: 8pt
+mainfont: "Arial"
+logo: "../../css/STT-1100_hex.png"
+---
+
+```{r}
+knitr::opts_chunk$set(echo = TRUE, eval = FALSE, message = FALSE, warning = FALSE)
+```
+
+
+# 🧰 WORK ENVIRONMENT
+
+## RStudio
+- Script: `Ctrl + Shift + N`
+- Render Quarto: `Ctrl + Shift + K`
+
+## Quarto
+```markdown
+---
+title: "Title"
+format: html
+---
+```
+
+Chunk R:
+````r
+```{r}
+summary(df)
+```
+````
+
+## Basic packages
+```r
+library(tidyverse)
+library(readr)
+library(UlavalSSD)
+library(palmerpenguins)
+```
+
+---
+
+# 📊 MANIPULATE DATA — `dplyr`
+
+## Basic
+
+```r
+select(df, col1)
+filter(df, col1 > 10)
+```
+
+## Transformation
+
+```r
+mutate(df, z = x/y)
+arrange(df, desc(x))
+```
+
+## Group and summarize
+
+```r
+group_by(df, cat)
+summarise(df, avg = mean(x, na.rm = TRUE))
+```
+
+---
+
+# 📈 VISUALIZATION — `ggplot2`
+
+## Digital
+
+```r
+ggplot(df, aes(x, y)) + geom_point()
+ggplot(df, aes(x)) + geom_histogram()
+```
+
+## Categorical
+
+```r
+ggplot(df, aes(x, fill = cat)) + geom_bar()
+ggplot(df, aes(cat, num)) + geom_boxplot()
+```
+
+🧠 Use `facet_wrap()` to compare multiple groups
+
+---
+
+# 📋 DESCRIPTIVE ANALYSIS
+
+## Digital statistics
+
+```r
+mean(x, na.rm=TRUE)
+sd(x)
+summary(df)
+```
+
+## Frequencies
+
+```r
+table(df$cat)
+prop.table(table(df$cat))
+```
+
+## `skimr`
+
+```r
+library(skimr)
+skim(df)
+```
+
+---
+
+# 🧠 GOOD PRACTICE TIPS
+
+- `glimpse(df)`: structure preview
+- `head(df)` / `tail(df)`
+- Comments `#` to clarify
+- Frequent commits in GitHub
+- Avoid ambiguous variable names

--- a/en/autre_materiel/Ou et comment chercher/ou et comment chercher.qmd
+++ b/en/autre_materiel/Ou et comment chercher/ou et comment chercher.qmd
@@ -1,0 +1,145 @@
+---
+title: "How to find and get help effectively?"
+subtitle: "STT-1100 — Introduction to Data Science"
+format: 
+  html:
+    toc: true
+    toc-title: "Plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Introduction
+
+A good data scientist doesn’t know everything by heart… but knows **where to look** and **how to ask for help** intelligently. This guide will help you learn how to do it effectively and stress-free.
+
+----------------------------------------------------------------------------------
+
+# 📝 The *cheat sheet* of the course
+
+A **summary cheat sheet** is available to support you throughout the course. This *cheat sheet* brings together:
+
+- The main functions and commands in R and tidyverse,
+- Practical examples for RStudio, GitHub and Quarto,
+- Useful reminders for cleaning, visualizing and modeling data.
+
+> You will find it on the MonPortail course site, updated regularly. Feel free to print it out or have it in front of you during your adventures.
+
+----------------------------------------------------------------------------------
+
+# 🤖 GPT STT-1100: your personalized assistant
+
+We have designed a **tailor-made GPT wizard for this course**: [GPT STT-1100](https://chatgpt.com/g/g-682d165f32e881918633affa3fe9dfd6-stt-1100)
+
+> He knows the objectives of the course, the modules, the challenges and the libraries used (like `UlavalSSD`). You can ask specific questions related to the course, such as:
+>
+> - *"How to import a `.csv` file with `readr`?"*
+> - *"How to make a graph with `ggplot2` for a numeric variable?"*
+> - *"What are the best practices for writing a reproducible report with Quarto?"*
+
+**Please note:** it does not replace critical thinking! But it is a valuable tool for progressing at your own pace.
+
+----------------------------------------------------------------------------------
+
+# 🧭 Where to look for help?
+
+## 📌 Integrated help in RStudio
+
+- Type `?function` or `help(function)` in the console.
+- Use RStudio's **Help** tab to navigate the documentation.
+- Type `example(function)` to get a ready-made example.
+- Also test the `args(function)` function to see the expected arguments.
+
+## 🌍 Search the web
+
+Billions of answers await you! Here are some tips for properly formulating your research:
+
+::: callout-tip
+**Formulate your questions like a pro:**
+
+- Bad: `it doesn't work with ggplot`
+- Best: `ggplot2 how to add color by group in scatterplot`
+
+**Recommended sites:**
+
+- [Stack Overflow](https://stackoverflow.com)
+- [Posit Community (formerly RStudio Community)](https://community.rstudio.com/)
+- [GitHub](https://github.com/search?q=your+error+message)
+- [Google](https://www.google.com) — type "r ggplot histogram group by color"
+:::
+
+----------------------------------------------------------------------------------
+
+# 📘 Course Resources
+
+## Recommended books and guides
+
+- [**R for Data Science** (2nd ed.)](https://r4ds.hadley.nz/)
+    - Complete guide to understand everything about tidyverse, scripts, graphics, etc.
+- [**The Tidyverse Style Guide**](https://style.tidyverse.org/)
+    - To write clear, clean and understandable code.
+- [**Introduction to Modern Statistics**](https://openintro-ims.netlify.app/)
+    - A complementary reference that emphasizes visualization, modeling, and modern statistics. This book is also free, clear and perfectly suited to beginners.
+- The **Quarto adventures (.qmd)** are there to help you progress step by step — don’t hesitate to come back to them if you get stuck.
+
+## Translate and understand key concepts
+
+If English slows you down:
+
+- Use [**DeepL**](https://www.deepl.com/translator) to translate explanations or error messages.
+- The **Google Chrome** browser offers **automatic translation of pages**.
+- Do not hesitate to **ask GPT STT-1100 to rephrase or translate** passages.
+
+> The concepts remain the same from one language to another — the important thing is to understand the ideas behind the commands!
+
+----------------------------------------------------------------------------------
+
+# 👩‍🏫 Ask for help effectively
+
+## 🤔 Before asking your question
+
+1. Have you read the entire error message?
+2. Have you tried searching with keywords?
+3. Can you isolate the problem in a simple example?
+
+## 🗣️ Ask a good question (to [GPT STT-1100](https://chatgpt.com/g/g-682d165f32e881918633affa3fe9dfd6-stt-1100), to an assistant or on the forum)
+
+- Be specific: indicate the **minimal** code that causes the error.
+- Copy the **full error message**.
+- Describe what you wanted to do and what is happening.
+
+::: callout-note
+**Example:**
+
+> I wanted to filter the data for penguins with a beak longer than 40mm.\
+> Here is the code:\
+> `penguins %>% filter(bill_length_mm > 40)`\
+> But I get the following error:\
+> `object 'bill_length_mm' not found`
+:::
+
+----------------------------------------------------------------------------------
+
+# 🚨 Don't get stuck alone!
+
+- 📩 **Write to the course forum.**
+- 💬 **Work in pairs or small groups**.
+- 🧑‍🏫 **Come and ask your question in class or to the assistant**.
+- 🤖 **Use GPT STT-1100 wisely**, but check what it responds to you.
+
+----------------------------------------------------------------------------------
+
+# 🎁 Bonus: reflexes to adopt
+
+✅ Find the information for yourself first\
+✅ Document what you learn (personal notes or `.qmd` file)\
+✅ Dare to ask questions!\
+✅ Learn from your mistakes (and those of others)
+
+----------------------------------------------------------------------------------
+
+> 🧠 *The best data scientists are not those who have all the answers... but those who know how to ask the right questions.*

--- a/en/autre_materiel/Présentation des différents rôles/roles_presentation.qmd
+++ b/en/autre_materiel/Présentation des différents rôles/roles_presentation.qmd
@@ -1,0 +1,166 @@
+---
+  title: "Panorama of data science professions"
+  subtitle: "Module 1 — STT‑1100"
+  author: "Laval University"
+  format:
+    revealjs:
+      theme:default
+      css: ulaval.css
+      slide-number: true
+      transition:slide
+      toc: true
+      toc-depth: 2
+      embed-resources: true
+      incremental: true
+---
+
+<!-- Title slide with course hex -->
+
+![](STT-1100_hex.png){fig-align="center" width="200"}
+
+# Introduction
+
+> *“It takes a village to turn data into value. »*\
+> In this presentation we will discover **who** makes up this village and **how** each role contributes to the cycle of a data science project.
+
+----------------------------------------------------------------------------------
+
+# The cycle of a data science project
+
+![](whole-game.png){fig-align="center"}
+
+:::notes
+Inspired by Hadley Wickham, *R for Data Science* 2nd ed. (https://r4ds.hadley.nz/whole-game.html).
+:::
+
+----------------------------------------------------------------------------------
+
+# Role mapping
+
+| Cycle phase | Key roles | Main objective |
+|------------------------|-----------------|------------------------------|
+| **Program** (Infrastructure) | *Data Engineer* | Build and maintain ingestion pipelines and storage platforms. |
+| **Import → Store** | *Data Owner* | Hold the data, ensure its quality, security and governance. |
+| **Understand** (Tidy → Transform → Visualize ↔ Model) | *Statistician · Data Scientist · Data Analyst* | Extract knowledge through analyzes and models. |
+| **Communicate** | *Data Journalist · Freelancer* | Tell the data story, popularize it and deliver value to stakeholders. |
+
+----------------------------------------------------------------------------------
+
+# DataEngineer 🛠️
+
+**Mission:** Provide reliable, accessible and well-structured data.
+
+**At work:**\
+- Designs architectures (ETL/ELT, lakes, warehouses).\
+- Automates import (`Import`), tidying (`Tidy`) and distribution.\
+- Collaborates closely with the *Data Owner* and prepares the ground for analysts.
+
+**Key skills:** Cloud, SQL, Python/R, CI/CD, security.
+
+::: fragment
+**Cycle connection:** Mainly in the "Program" area and at the beginning of "Understand" (Import → Tidy).
+:::
+
+----------------------------------------------------------------------------------
+
+# DataOwner 🔑
+
+**Mission:** Guarantee governance, compliance and data quality.
+
+**Responsibilities:**\
+- Defines metadata, access and privacy policies.\
+- Validates the source and supervises updates.\
+- Is the legal and organizational point of contact.
+
+**Link to the cycle:** Provides the *raw material* and validates each change before distribution.
+
+----------------------------------------------------------------------------------
+
+# Statistician 📐
+
+**Mission:** Model phenomena and quantify uncertainty.
+
+**At work:**\
+- Chooses the right methods (inference, sampling, experimentation).\
+- Evaluates hypotheses, builds and interprets models.\
+- Guarantees the robustness and validity of the conclusions.
+
+**Link to cycle:** At the heart of `Model`, with a strong loop to `Visualize` to diagnose and explain.
+
+----------------------------------------------------------------------------------
+
+# DataScientist 🔬
+
+**Mission:** Transform data into high value-added products and recommendations.
+
+**At work:**\
+- Combines programming, statistics and business domain.\
+- Quickly iterates between `Transform`, `Visualize` and `Model`.\
+- Puts solutions into production (API, dashboards).
+
+**Key skills:** Python/R, ML, MLOps, storytelling, experimentation.
+
+----------------------------------------------------------------------------------
+
+# DataAnalyst 📊
+
+**Mission:** Provide operational insights and support day-to-day decision-making.
+
+**At work:**\
+- Prepare reports, KPIs, dashboards.\
+- Queries the basics, aggregates, creates clear visualizations.\
+- Collaborates with the Data Engineer to ensure data freshness.
+
+**Link with the cycle:** Mainly exploits `Transform` and `Visualize`, communicates in the final phase.
+
+----------------------------------------------------------------------------------
+
+# DataJournalist 📰
+
+**Mission:** Tell engaging stories based on verifiable data.
+
+**At work:**\
+- Searches public bases, checks the facts.\
+- Creates interactive visualizations and narratives.\
+- Popularizes for a wide audience and defends transparency.
+
+**Link with the cycle:** Emphasizes `Communicate`, draws on the work of other roles for the technical part.
+
+----------------------------------------------------------------------------------
+
+# Freelancer 💼
+
+**Mission:** Provide timely and adaptable expertise over all or part of the cycle.
+
+**Special features:**\
+- Versatility: must understand each role to intervene effectively.\
+- Project management, customer relations and technological monitoring.\
+- Can fill gaps in an internal team.
+
+----------------------------------------------------------------------------------
+
+# Collaboration and assists ⚽
+
+``` mermaid
+flowchart LR
+  subgraph Cycle
+    A[Import] --> B[Tidy] --> C[Transform] --> D[Visualize] <--> E[Model] --> F[Communicate]
+  end
+  classDef engineer fill:#d9d9d9,stroke:#e30513,color:#000;
+  classDef owner fill:#ffc103,stroke:#e30513,color:#000;
+  classDef analyst fill:#ffffff,stroke:#e30513,color:#000;
+  class A,B engineer;
+  class B,C analyst;
+  class D,E statistician;
+  class F journalist;
+```
+
+----------------------------------------------------------------------------------
+
+# Conclusion
+
+- Each role **brings unique expertise** but *none* is enough alone.\
+- **Communication** and **governance** ensure consistency.\
+- In this course, you will put on different hats to experience **the whole cycle**!
+
+> *Welcome to the STT‑1100 adventure!* 🎉 \`\`\`\`

--- a/en/autre_materiel/Présentation des différents rôles/roles_presentation_v2.qmd
+++ b/en/autre_materiel/Présentation des différents rôles/roles_presentation_v2.qmd
@@ -1,0 +1,138 @@
+---
+title: "Panorama of data science careers – Module 1 (STT-1100)"
+format:
+  revealjs:
+    theme:default
+    css: [../../css/ulaval_logo.css]
+    slide-number: true
+    transition:slide
+    toc: true
+    toc-depth: 2
+    embed-resources: true
+    incremental: true
+    mermaid: {} 
+---
+
+# Introduction
+
+> *“It takes a village to turn data into value. »*\
+> In this presentation we will discover **who** makes up this village and **how** each role contributes to the cycle of a data science project.
+
+# The cycle of a data science project
+
+![](whole-game.png){fig-align="center" width="800"}
+
+:::notes
+Inspired by Hadley Wickham, *R for Data Science* 2nd ed. (https://r4ds.hadley.nz/whole-game.html).
+:::
+
+- **Import**\
+    Load raw data from their sources into the work environment.
+
+- **Tidy**\
+    Rearrange the data so that one row corresponds to an observation and one column to a variable.
+
+- **Transform**\
+    Filter, aggregate and create new variables to prepare information for analysis.
+
+- **Visualize**\
+    Explore data using graphs to reveal trends, relationships and anomalies.
+
+- **Model**\
+    Build statistical or machine learning models to explain or predict.
+
+- **Communicate**\
+    Present results, limitations and recommendations in a clear and actionable manner to stakeholders.
+
+# Role mapping
+
+| Cycle phase | Key roles | Main objective |
+|------------------------|-----------------|------------------------------|
+| **Program** (Infrastructure) | *Data Engineer* | Build and maintain data pipelines. |
+| **Import → Store** | *Data Owner* | Hold the data, ensure its quality, security and governance. |
+| **Understand** (Tidy → Transform → Visualize ↔ Model) | *Statistician · Data Scientist · Data Analyst* | Extract knowledge through analyzes and models. |
+| **Communicate** | *Data Journalist · Freelancer* | Tell the data story, popularize it and deliver value to stakeholders. |
+
+# DataEngineer 🛠️
+
+**Mission:** Provide reliable, accessible and well-structured data.
+
+**At work:**\
+- Designs data architectures.\
+- Automates import (`Import`), tidying (`Tidy`) and distribution.\
+- Collaborates closely with the *Data Owner* and prepares the ground for analysts.
+
+::: fragment
+**Cycle connection:** Mainly in the "Program" area and at the beginning of "Understand" (Import → Tidy).
+:::
+
+# DataOwner 🔑
+
+**Mission:** Guarantee governance, compliance and data quality.
+
+**Responsibilities:**\
+- Defines metadata, access and privacy policies.\
+- Validates the source and supervises updates.\
+- Is the legal and organizational point of contact.
+
+**Link to the cycle:** Provides the *raw material* and validates each change before distribution.
+
+# Statistician 📐
+
+**Mission:** Model phenomena and quantify uncertainty.
+
+**At work:**\
+- Chooses the right methods (inference, sampling, experimentation).\
+- Evaluates hypotheses, builds and interprets models.\
+- Guarantees the robustness and validity of the conclusions.
+
+**Link to cycle:** At the heart of `Model`, with a strong loop to `Visualize` to diagnose and explain.
+
+# DataScientist 🔬
+
+**Mission:** Transform data into high value-added products and recommendations.
+
+**At work:**\
+- Combines programming, statistics and business domain.\
+- Quickly iterates between `Transform`, `Visualize` and `Model`.\
+- Puts solutions into production.
+
+# DataAnalyst 📊
+
+**Mission:** Provide operational insights and support day-to-day decision-making.
+
+**At work:**\
+- Prepare reports, performance indexes and dashboards.\
+- Queries the basics, aggregates, creates clear visualizations.\
+- Collaborates with the Data Engineer to ensure data validity.
+
+**Link with the cycle:** Mainly exploits `Transform` and `Visualize`, communicates in the final phase.
+
+# DataJournalist 📰
+
+**Mission:** Tell engaging stories based on verifiable data.
+
+**At work:**\
+- Searches public databases, checks facts.\
+- Creates interactive visualizations and narratives.\
+- Popularizes for a wide audience and defends transparency.
+
+**Link with the cycle:** Emphasizes `Communicate`, draws on the work of other roles for the technical part.
+
+# Freelancer 💼
+
+**Mission:** Provide timely and adaptable expertise over all or part of the cycle.
+
+**Special features:**\
+- Versatility: must understand each role to intervene effectively.\
+- Project management, customer relations and technological monitoring.\
+- Can fill gaps in an internal team.
+
+
+# Conclusion
+
+- Each role **brings unique expertise** but *none* is enough alone.\
+- **Communication** and **governance** ensure consistency.\
+- In this course, you will put on different hats to experience **the whole cycle**!
+
+> *Welcome to the STT‑1100 adventure!* 🎉

--- a/en/index.qmd
+++ b/en/index.qmd
@@ -1,0 +1,56 @@
+---
+title: "Home"
+format:
+  html:
+    css: ../css/base_css.css
+    toc:false
+---
+
+# Welcome to Data Science 👋
+
+**STT-1100 Introduction to Data Science**
+
+This site brings together all the course notes, exercises and projects for your session.
+
+---
+
+## 🗺️ Your learning journey
+
+This course is designed to immerse you in the reality of being a data scientist. Each module is structured around an immersive approach:
+
+::: {.grid}
+
+::: {.g-col-4}
+### 🧭 1. The Adventure
+**A professional situation.**
+You are not just a student, you are a consultant, junior analyst or commissioned expert. You learn the concepts by solving a real-world problem for a fictional customer.
+:::
+
+::: {.g-col-4}
+### ⚔️ 2. The Challenge
+**Your independent mission.**
+After learning the necessary tools during the adventure, you must complete a technical challenge to prove your mastery. It's time to get your hands dirty!
+:::
+
+::: {.g-col-4}
+### 📚 3. The Plan
+**Your resources.**
+Each module begins with a clear learning plan and targeted readings to prepare you for the adventure.
+:::
+
+:::
+
+---
+
+## 🎯 Course objectives
+
+1. **Master the tools**: RStudio, GitHub, Quarto.
+2. **Manage data**: Import, cleaning, transformation.
+3. **Analyze and Visualize**: Create impactful graphs and statistical analyses.
+4. **Collaborate**: Work as a team in a repeatable and ethical manner.
+
+---
+
+## 🚀 Ready to get started?
+
+Go to the side menu to access **Module 1** and start your first adventure!

--- a/en/module_01/aventure.qmd
+++ b/en/module_01/aventure.qmd
@@ -1,0 +1,564 @@
+---
+title: "Adventure 1 - Dive into data science"
+subtitle: "STT-1100 Introduction to Data Science"
+author: 
+  - institute: “Laval University”
+editor:visual
+editor_options: 
+  chunk_output_type: console
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    css: [../css/base_css.css]
+    self-contained: true
+# number-sections: true
+---
+
+# How to pass this module {.unnumbered}
+
+Welcome to this first data science adventure! This module is designed to provide you with a comprehensive introduction to the fundamental tools and concepts that will support you throughout your data science journey.
+
+- **Read each section carefully** before proceeding with the experiment. Theoretical explanations provide the basis for understanding the practical examples.
+
+- **Actively experiment** by running the proposed code and exploring the results. Feel free to modify the examples to test your ideas.
+
+- **Ask questions** if you encounter difficulties or if certain concepts remain unclear.
+
+This module is a gateway to the vast world of data science. Take the time to explore each step, and have fun learning!
+
+# IT tools
+
+In this course, we will use professional computing tools that are essential in data science. These tools allow data to be manipulated, analyzed and visualized in an efficient and reproducible manner. Here is an overview of the main tools that you will discover:
+
+**RStudio**: An Integrated Development Environment (IDE) for R that makes it easy to write scripts, run code, and manage projects. It offers an intuitive interface and many professional features to help you structure your analyses.
+
+**Quarto**: a powerful tool for producing reproducible documents that combine explanatory text, code and results. With Quarto, you can generate professional reports, presentations and even websites.
+
+These tools are not limited to their technical aspect; they also promote good practices in data science, such as rigorous project organization, clear documentation and reproducibility of analyses. They will be your allies throughout this course and your future experiences in data science.
+
+## Discovery of RStudio
+
+RStudio is an integrated development environment (IDE) for R. It makes it easy to write, run, and manage projects in R, while integrating many professional features. Here is an overview of its main windows and functionalities:
+
+### The main windows of RStudio
+
+RStudio is made up of four main panels:
+
+- **Console**: generally located at the bottom left, it allows you to directly execute commands in R.
+
+- **Script**: at the top left, this is the place where you write and save your scripts (`.R` or `.qmd` files). You can notice that this adventure is indeed a `.qmd` in the script window.
+
+- **Environment**: at the top right, it displays the objects currently available in memory (*datasets*, variables, functions).
+
+- **Graph (*Plots*), files and help**: at the bottom right, this panel allows you to view your graphs, explore the project files, or access the documentation.
+
+::: callout-note
+#### Example
+
+- **Test the console**: open the console and type the following command:
+
+    ``` r
+    print("Hello, RStudio!")
+    ```
+
+    Observe the result displayed directly in the console.
+
+- **Create a script**: Click `File > New File > R Script`, write the following code and run it with `Ctrl + Enter` (Windows/Linux) or `Cmd + Enter` (Mac):
+
+    ``` r
+    message("You are working in an R script!")
+    ```
+
+    Save the file under the name `test_script.R`.
+:::
+
+### Important features
+
+- **Projects**: RStudio organizes your work into projects, which is ideal for structuring your files and data. We will work on projects from the next module.
+
+- **Integrated Terminal**: to execute system commands without leaving RStudio. We won't use it for the moment but know that it exists.
+
+- **Packages**: the "Packages" tab allows you to easily install and load libraries.
+
+::: callout-tip
+#### Exercise
+
+Install the `dplyr` package using the GUI or via the following command in the console:
+
+```{r, eval=FALSE}
+install.packages("dplyr")
+```
+
+Once installed, load it with:
+
+```{r, eval=FALSE}
+library(dplyr)
+```
+:::
+
+### Configure your environment
+
+To get started efficiently, customize the preferences (`Tools > Global Options`) to adjust the appearance and settings according to your needs.
+
+::: callout-tip
+#### Exercise
+
+- **Exploring options**: Access `Tools > Global Options` and explore the different possible configurations. Try changing the interface theme (e.g. dark theme) and see the difference.
+:::
+
+## Basics of programming in R
+
+R programming is essential for manipulating, analyzing and visualizing data. This section introduces you to the basics of programming and offers you exercises to practice.
+
+### Create and manipulate objects
+
+In R, everything is an object. Here are the basics for creating objects and manipulating them:
+
+::: callout-tip
+#### Exercise
+
+- **Create an object**:
+
+    ``` r
+    x <- 42 # Assigns the value 42 to the object x
+    print(x) # Print the value of x
+    x # Also displays the value of x
+    ```
+
+- **Manipulate a vector**:
+
+    ``` r
+    vector <- c(1, 2, 3, 4, 5) # Creates a vector
+    sum <- sum(vector) # Calculates the sum of the elements
+    sum
+    ```
+
+- Create a vector containing the numbers 1 to 10 and calculate its average using the `sum()` function.
+:::
+
+### Write conditions
+
+Conditions allow you to make your scripts dynamic.
+
+::: callout-note
+#### Example
+
+- **Simple condition**:
+
+    ``` r
+    number <- 10
+    if (number > 5) {
+      print("The number is greater than 5")
+    } else {
+      print("The number is less than or equal to 5")
+    }
+    ```
+:::
+
+::: callout-tip
+#### Exercise
+
+- Write a condition that displays whether a number is even or odd.
+
+Hint: the `%%` function in R gives the remainder of the Euclidean division. For example `10%%2` is 0 because $10=5\times2$.
+:::
+
+### Built-in basic functions
+
+R has many built-in functions to perform simple or advanced calculations. For example, there is the `mean` function which, as its name suggests, allows you to calculate an average.
+
+The following code block allows us to calculate the average of the vector `(1, 3, 5, 7)`.
+
+```{r}
+x <- c(1, 3, 5, 7) # Defines the vector x
+mean(x) # Call the mean function on x
+```
+
+When you want help with a function, you can simply type the name of it in the help tab in the bottom right dial.
+
+### Define a new function
+
+R also allows us to define our own functions. We will do this several times in the course. Here is a simple little example.
+
+::: callout-note
+#### Example
+
+- **Basic calculation**:
+
+    ``` r
+    square <- function(x) {
+      return(x^2)
+    }
+    print(square(4))
+    ```
+:::
+
+::: callout-tip
+#### Exercise
+
+- Create a `cube` function that calculates the cube of a number, then test it with the values 2, 3 and 4.
+:::
+
+### Good programming practices
+
+Here are some tips for writing clean, maintainable code:
+
+#### Golden rules
+
+1. **Name your objects descriptively**:
+
+    ``` r
+    average_notes <- mean(c(80, 85, 90))
+    ```
+
+2. **Organize your script with comments**:
+
+    ``` r
+    # Calculation of the sum
+    sum <- sum(vector)
+    ```
+
+In the course, you must follow the [tydiverse coding best practices](https://style.tidyverse.org/). For this module, we will pay particular attention to certain parts of this guide: chapter 1 Files, chapter 2 Syntax and section 3.1 Functions/Naming. The table below summarizes the important criteria of these sections and will serve as an evaluation grid for your codes. Note that this grid will evolve over the modules.
+
+```{r, echo=FALSE}
+library(knitr)
+kable(
+  data.frame(
+    Criterion = c("Syntax and indentation", "Spaces and readability", "Line length", "Assignment", "Object naming", "Function style", "Consistency and clarity", "Useful comments"),
+    Explanation = c(
+      "Respect for indentation and code structure (2 spaces per nesting level, no tabulation)",
+      "Consistent spaces around operators (`<-`, `=`, `+`, etc.) and after commas to improve readability.",
+      "Lines of code do not exceed 80 characters (except for justified exceptions)",
+      "Using `<-` instead of `=` for assigning values.",
+      "Use of explicit names and in `snake_case` Ex: `ma_variable` rather than `MaVariable` or `maVariable`.",
+      "Spaces after commas, no spaces before opening parentheses. Ex: `mean(x, na.rm = TRUE)`.",
+      “The code is written in a clear and understandable manner, avoiding unnecessary complexity.”,
+      "Comments are concise and helpful, without being redundant. Use of `#` with a space after it."    )
+  ),
+  caption = "R code evaluation grid according to tidyverse style."
+)
+```
+
+::: callout-tip
+#### Exercise
+
+- Identify style errors in code.
+
+- Correct them by applying tidyverse style best practices.
+
+    ``` r
+    MyFunction = function(x,y){
+    result=x+y
+    return(result) }
+
+    df=data.frame(id=1:5,name=c("Alice","Bob","Charlie","David","Eva"))
+    df_filtered = subset(df, id>2)
+    df_selected = df_filtered[,c("name")]
+    df_selected$Upper = toupper(df_selected$name)
+    mean(c(1,2,3,4,5),na.rm=TRUE)
+    ```
+:::
+
+```{r eval=FALSE, echo= FALSE}
+# Define a function with an explicit name and well formatted
+my_function <- function(x, y) {
+  result <- x + y
+  return(result)
+}
+
+# Create a data frame with tibble (optional, otherwise data.frame remains valid here)
+df <- data.frame(
+  id = 1:5,
+  name = c("Alice", "Bob", "Charlie", "David", "Eva")
+)
+
+# Filter rows with id > 2
+df_filtered <- df[df$id > 2, ]
+
+# Select the "name" column
+df_selected <- df_filtered[, c("name")]
+
+# Add a column with names in uppercase
+df_selected$upper <- toupper(df_selected$name)
+
+# Calculate the average
+mean(c(1, 2, 3, 4, 5), na.rm = TRUE)
+```
+
+## Introduction to Quarto
+
+Quarto is a powerful tool for creating reproducible documents combining text, code, and results. It supports different formats, such as HTML, PDF and Word.
+
+### What is Quarto?
+
+Quarto lets you combine R, Python or Julia code with textual explanations, while generating professional reports. Of course, in this course we will use it with R. Its main advantages include:
+
+- **Reproducibility**: the code and the results are directly integrated into the same document.
+
+- **Versatility**: possibility of generating various types of files (reports, presentations, websites).
+
+- **Ease of use**.
+
+### Structure of a Quarto document
+
+A Quarto file always starts with a YAML header, followed by Markdown content and chunks of code.
+
+#### Basic Quarto file example
+
+``` yaml
+---
+title: "My first Quarto document"
+format: html
+editor:visual
+---
+```
+
+#### Insert a *chunk* (block of code) R
+
+To insert a *chunk* (block of code) into a quarto document, you can click on the following symbol:
+
+![Button to add a code block in Rstudio](resources/bouton_chunck.png)
+
+```{r}
+# This is a block of code
+2+2
+```
+
+You can easily execute a block of code either by executing (`Ctrl + Enter`) line by line or by clicking on the small green arrow in the upper left corner of the code block. You will notice that your results appear below the code box.
+
+Once your report is final, you can generate the report by clicking on the Render button: ![Button to add generate report](resources/bouton_render.png)
+
+::: callout-note
+#### Example
+
+- **Create a Quarto document**:
+    1. Click `File > New File > Quarto Document`.
+    2. Choose the desired format (HTML, PDF, Word) and generate a basic document.
+    3. Insert a code block with `Ctrl + Alt + I` shortcut (or symbol) and add R code (a simple trick).
+- **Generate the document**: Use `Ctrl + Shift + K` (or the render button) to generate the final report.
+:::
+
+::: callout-tip
+#### Exercise
+
+1. Create a Quarto document in HTML format.
+2. Add an R code block to display a summary of the `mtcars` dataset (this is `summary(mtcars)`).
+3. Customize the YAML header to include your name and a date.
+:::
+
+# Library and data
+
+We saw above that you can improve your R experience by using libraries. As part of the course, we will use a library called `UlavalSSD`. This is a library developed for the course.
+
+## `UlavalSSD`
+
+First, you will install the `UlavalSSD` library and load it into your working environment.
+
+```{r eval=FALSE}
+# Install the remotes package if necessary
+install.packages("remotes")
+
+# Install UlavalSSD from GitHub
+remotes::install_github("AurelienNicosiaULaval/UlavalSSD")
+```
+
+```{r}
+library(UlavalSSD)
+```
+
+Loading the library will allow us to access all of its contents. You can see the library help files with the following code (or by searching in the package tab on the right)
+
+```{r}
+help(package = "UlavalSSD")
+```
+
+::: callout-tip
+#### Exercise
+
+- Search the contents of the bookstore. What do you notice?
+:::
+
+## `MeteoQuebec` data
+
+In this adventure, we will work with the dataset called `MeteoQuebec` available in the `UlavalSSD` library. It is important to note that if the library is not loaded (`library(UlavalSSD)`) then you will not be able to access this dataset.
+
+::: callout-tip
+#### Exercise
+
+- `MeteoQuebec` is an object name in the environment. Display the database by creating a code block.
+- How many rows and columns does this dataset have?
+- Explore the help to make sure you understand what each column represents.
+:::
+
+# Clean data (`Tidy` in English)
+
+## What is clean data?
+
+In the context of data science, **clean data** refers to a set of data that is ready to be used for analyses. This means that the data is organized, consistent, and free of errors or inconsistencies. Working with clean data is essential to ensure the quality of analysis results and models.
+
+### Characteristics of clean data
+
+Clean data must meet the following criteria:
+
+- **No missing values**: All data necessary for the analysis is present.
+- **Uniformity of formats**: The formats of dates, numbers and character strings are consistent.
+- **No duplicates**: Duplicate entries have been identified and removed if necessary.
+- **Error Removal**: Inconsistent or incorrect data has been corrected.
+- **Well-defined columns**: Each column has a clear and unique meaning.
+- **One line per observation**: The data is structured in a tabular manner, with one line representing a single observation.
+
+### Example of non-clean data
+
+A table containing the following data:
+
+| Name | Date of Birth | Score |
+|--------|----------------|-------|
+| Alice | 01/01/1990 | 85.5 |
+| Bob | 1990-02-15 | 90 |
+| Charlie |                | 87.5 |
+| Alice | 01/01/1990 | 85.5 |
+
+Problems: - The date format is not consistent. - A line contains a missing value (Birth Date for Charlie). - The data contains a duplicate for Alice.
+
+### Example of clean data
+
+After cleaning, the data becomes:
+
+| Name | Date of Birth | Score |
+|--------|----------------|-------|
+| Alice | 1990-01-01 | 85.5 |
+| Bob | 1990-02-15 | 90.0 |
+| Charlie | 1992-03-20 | 87.5 |
+
+- The date format is uniform (YYYY-MM-DD).
+- Duplicates have been removed.
+- Missing values ​​have been completed or deleted.
+
+In the coming weeks we will have a complete module on data cleansing. This is simply to introduce you to the concept of clean data so that you are attentive to this aspect every time you encounter data.
+
+::: callout-tip
+#### Exercise
+
+- In the `MeteoQuebec` dataset, check if there is any missing data. You can use the `summary` function for this. When we apply the `summary` function to a dataset, it gives us descriptive statistics (we will come back to this), but above all it gives the number of missing data per column.
+
+- Are the `MeteoQuebec` data clean? Justify your answer.
+:::
+
+# Data manipulation
+
+In this section, we will learn how to manipulate simple data tables in R. You will discover how to extract a row, a column and create a new column using the brackets `[]` and the operator `$`.
+
+## Example of data table
+
+We will use `MeteoQuebec` data. The `head` function is very practical, because as its name suggests, it displays the top (the head) of the database. This allows you to have quick access to the information contained in the variables.
+
+```{r}
+# Displaying the top of the dataset
+head(MeteoQuebec)
+```
+
+### Extract a line with brackets `[]`
+
+To extract a specific row, use the format `data_name[row_number, ]`.
+
+Example: Let's get the 2nd line:
+
+```{r}
+# Extract the 2nd line
+line_2 <- MeteoQuebec[2, ]
+print(line_2)
+```
+
+### Extract a column with brackets `[]`
+
+To extract a column, you can use `data_name[, column_number]` or `data_name[["column_name"]]`.
+
+**Attention**, usually we prefer to extract a column by its name rather than by its number. First of all, if your dataset contains many columns, it will become tedious to find the right number. Also, to be reproducible, it is better to work with the name, since even if the order of the columns changes, your analysis will remain valid.
+
+Example: Let's get the **total_precip** column:
+
+```{r,eval=FALSE}
+# Method 1: By column number
+column_score <- MeteoQuebec[, 7]
+print(score_column)
+
+#Method 2: By column name
+column_score2 <- MeteoQuebec[["total_precip"]]
+print(column_score2)
+```
+
+### Extract a column with the `$` operator
+
+A simpler method to extract a column is to use the `$` operator.
+
+Example: Let's get the **mean_temp** column:
+
+```{r,eval=FALSE}
+# Extract the "mean_temp" column
+column_mean_temp <- MeteoQuebec$mean_temp 
+print(column_mean_temp)
+```
+
+::: callout-note
+#### Example
+
+- In the console, type the name of the database `MeteoQuebec`, add a `$` at the end. What is happening?
+:::
+
+### Add a new column with `$`
+
+To create a new column, use the `$` operator and assign a value to it.
+
+Example: Let's add a column **extended_temp**, equal to **max_temp-min_temp**:
+
+```{r}
+# Add a new column
+MeteoQuebec$extended_temp <- MeteoQuebec$max_temp -MeteoQuebec$min_temp
+head(MeteoQuebec)
+```
+
+::: callout-tip
+#### Exercise
+
+- Create a new column **mean_temp_F** which corresponds to the average temperature per day in degrees fahrenheit.
+:::
+
+### Filter rows based on logical conditions
+
+You can use logical conditions with `[]` brackets to extract specific lines.
+
+Example: Let's get the lines where the average temperature **mean_temp** is greater than 25:
+
+```{r,eval=FALSE}
+# Extract rows with a Score > 85
+lines_mean_temp_25 <- MeteoQuebec[MeteoQuebec$mean_temp > 25, ]
+print(lines_mean_temp_25)
+```
+
+::: callout-tip
+#### Exercise
+
+- Get the lines where the precipitation total **total_precip** is zero:
+- Obtain the subset of data for the month of June only.
+:::
+
+**Combine multiple conditions with** `&` or `|`:
+
+- **AND (`&`)**: All conditions must be true to include a line.
+- **OR (`|`)**: At least one of the conditions must be true to include a line.
+
+Here is an example where we will look for the subset of data corresponding to the days in the year 2000 for which there was no precipitation.
+
+```{r,eval=TRUE}
+head(MeteoQuebec[MeteoQuebec$year == 2000 & MeteoQuebec$total_precip == 0,])
+```
+
+### Summary
+
+| Action | Order |
+|----|----|
+| Extract a row | `data[line_number, ]` |
+| Extract a column (brackets) | `data[, column_number]` or `data[["column_name"]]` |
+| Extract a column (`$`) | `data$column_name` |
+| Add a new column | `data$new_column <- ...` |

--- a/en/module_01/defi.qmd
+++ b/en/module_01/defi.qmd
@@ -1,0 +1,62 @@
+---
+title: "Challenge 1 - Dive into data science"
+subtitle: "STT-1100 Introduction to Data Science"
+author: 
+  - institute: “Laval University”
+editor:visual
+editor_options: 
+  chunk_output_type: console
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    css: [../css/base_css.css]
+    self-contained: true
+---
+
+# Presentation of the challenge
+
+You must create a Quarto report in HTML format. Your report must include:
+
+- a meaningful header (title, date and author);
+- three sections: introduction, analysis and conclusion.
+
+The report must answer the following question: **"*Was I born in the right year?***". We can answer this question by looking at the average temperature observed on the day of your birth, comparing it to those of previous or following years.
+
+In the *introduction*** you will need to name the objective of your analysis, the chosen date and the database you will use to answer it.
+
+In the ***analysis*** section, you will need to carry out a simple analysis of the `MeteoQuebec` database from the `UlavalSSD` library. Here are the steps to follow:
+
+1. Give the average temperature on your day of birth.
+
+2. Analyze average temperatures by comparing your day of birth with data from 5 consecutive years before and 5 years after your year of birth. This will allow you to determine if the average temperature on the day you were born was more favorable.
+
+In the ***conclusion*** section, you must answer the challenge question with text.
+
+[*Important note*]{.underline} **:**\
+If the data for your day of birth contains missing values, for example for average temperature, you can choose another symbolic date, such as the birthday of a family member, friend or pet.
+
+# Expected deliverables
+
+- An HTML report;
+
+- Your source file `.qmd`.
+
+- Your `.qmd` report must respect tidyverse good coding practices (chapter 1 and 2)
+
+# Evaluation grid
+
+## 📢 Important note
+
+> For this **first rendering of a Quarto report**, you will receive **formative feedback** from the teacher.\
+> It will be based on the following grid in order to help you progress and improve your next deliverables.
+
+| Criterion | Great | Satisfactory | To improve |
+|------------------|------------------|------------------|------------------|
+| **Presentation of the report** | Complete header (title, author, date). Three clearly identified sections. | Some elements are missing or unclear sections. | Absent structure or missing essential elements. |
+| **Introduction** | Clear objective, chosen date justified, data source named. | Unclear objective or date. Source not mentioned. | Lack of introduction or off-topic. |
+| **Analysis of the temperature of the chosen day** | Correct extraction, interpreted value. | Partial extraction or limited commentary. | Data missing or incorrect. |
+| **Comparison over 11 years (±5)** | Complete analysis, relevant interpretation, good use of graphics if present. | Existing analysis but simplistic or unclear. | Absent or incorrect analysis. |
+| **Conclusion** | Logical answer, well justified with a return to the initial question. | Answer present but not well argued. | Answer missing or off topic. |
+| **Code quality (`.qmd`)** | Clear style, consistent indentation, respect for tidyverse conventions. | Acceptable style with some deviations. | Messy or poorly readable style. |
+| **Reproducibility (`.html`)** | Report rendered complete, HTML functional. | Partial report or with minor errors. | HTML file non-functional or missing. |

--- a/en/module_01/exercices_corriges.qmd
+++ b/en/module_01/exercices_corriges.qmd
@@ -1,0 +1,27 @@
+---
+title: "Answers exercise module 1 - Dive into data science"
+author: "Aurélien Nicosia"
+format: html
+editor:visual
+---
+
+## Quarto
+
+Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.
+
+## Running Code
+
+When you click the **Render** button a document will be generated that includes both content and the output of embedded code. You can embed code like this:
+
+```{r}
+1 + 1
+```
+
+You can add options to executable code like this
+
+```{r}
+#| echo:false
+2*2
+```
+
+The `echo: false` option disables the printing of code (only output is displayed).

--- a/en/module_01/plan_apprentissage.qmd
+++ b/en/module_01/plan_apprentissage.qmd
@@ -1,0 +1,196 @@
+---
+title: "Module 1 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# Module objectives
+
+At the end of this module, you should be able to
+
+- Use RStudio to write and run R code using the console and scripts.
+
+- Install and load libraries.
+
+- Create and manipulate R objects, use conditions, use existing functions, write simple functions.
+
+- Write R code following tidyverse style conventions.
+
+- Check if a dataset is clean.
+
+- Extract a row or column, add a column, filter data using one or more conditions.
+
+- Write a simple report in Quarto, including text, code blocks, section titles.
+
+# Initial readings
+
+## 📘 The reference book
+
+In this course, we will regularly rely on the book **R for Data Science** (*2nd edition*, by Hadley Wickham, Mine Çetinkaya-Rundel and Garrett Grolemund).
+
+> Note: we will often abbreviate with **R4DS**
+
+It is an **indispensable reference**, accessible free online and written in clear **English**. You will find complete explanations and concrete examples to learn how to work effectively with `tidyverse`.
+
+**👉 Tip**: If in doubt or stuck, consult the document [How to search and get help](../references.qmd).
+
+----------------------------------------------------------------------------------
+
+### To read for this module
+
+- [Book homepage](https://r4ds.hadley.nz/){target="_blank"}\
+    *An overview of the book, its authors and the themes covered in each part.*
+
+- [Introduction](https://r4ds.hadley.nz/intro.html){target="_blank"}\
+    *Why learn R for data science, and how to approach your learning in this course.*
+
+- [Workflow: basics](https://r4ds.hadley.nz/workflow-basics.html){target="_blank"}\
+    *The first steps in RStudio: the environment, scripts and interactive behavior of R.*
+
+- [Workflow: scripts](https://r4ds.hadley.nz/workflow-scripts.html){target="_blank"}\
+    *Why use scripts to make your work reproducible, clear and well structured.*
+
+# Adventure
+
+This module is designed to provide you with a comprehensive introduction to the fundamental tools and concepts that will support you throughout your data science journey.
+
+[Module 1 Adventure](aventure.qmd)
+
+# Challenge
+
+In this first challenge, in order to get used to the different tools, you must create a Quarto report in HTML format.
+
+[Module 1 challenge](defi.qmd)
+
+## Further reading
+
+### 🧠 Deepen best practices
+
+Once the foundations have been laid, it is essential to adopt **clear, reproducible and consistent work habits** from the start. The resources below will help you improve the readability, structure, and organization of your code.
+
+----------------------------------------------------------------------------------
+
+### 🔧 R4DS Add-ons
+
+- [Workflow: help](https://r4ds.hadley.nz/workflow-help.html)\
+    *Learn to ask the right questions, search documentation effectively, and make relevant requests for help.*
+
+- [Quarto formats](https://r4ds.hadley.nz/quarto-formats.html)\
+    *Introduction to the formats available in Quarto and how to customize your reports, articles or presentations.*
+
+- [Workflow:style](https://r4ds.hadley.nz/workflow-style.html)\
+    *Why a consistent code style is crucial for collaboration and how to achieve it with tidyverse style.*
+
+----------------------------------------------------------------------------------
+
+### 📐 Tidyverse Style Guide
+
+- [Chapter 1: Files](https://style.tidyverse.org/files.html)\
+    *Tips for organizing your files, structuring your projects and naming your scripts clearly.*
+
+- [Chapter 2: Syntax](https://style.tidyverse.org/syntax.html)\
+    *Syntax rules for writing readable code, spacing, indentation and naming conventions.*
+
+# Consolidation exercises
+
+To put the learning from this module into practice, you will find below a series of exercises taken from the manual or adapted for STT-1100.
+
+## Exercise 1 — Why learn R?
+
+In one or two sentences, explain why learning R is useful for someone who wants to work with data.
+
+::: {.callout-tip collapse="true"}
+R is a powerful language designed for data manipulation, analysis and visualization. It is widely used in data science for its wealth of libraries and its integration with tools like Quarto.
+:::
+
+## Exercise 2 — The console vs the script
+
+In RStudio, type `3 + 4` in:
+
+1. the console
+
+2. a `.R` script which you then run with `Ctrl + Enter`
+
+What is the difference between the two approaches?
+
+::: {.callout-tip collapse="true"}
+The console allows code to be executed immediately, but does not keep track. The script allows code to be written and saved, which is essential for reproducibility.
+:::
+
+## Exercise 3 — Script structure
+
+Create an `analysis.R` file containing the following elements:
+
+- a header with your name and date
+
+- a library loading (`tidyverse`)
+
+- a simple statement (`mean(c(1, 2, 3, 4))`)
+
+::: {.callout-tip collapse="true"}
+``` r
+# Weather analysis — A. Nicosia
+# Date: 2025-05-19
+
+library(tidyverse)
+
+mean(c(1, 2, 3, 4))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 4 — Finding help
+
+Use R's built-in help to understand how to use the `mean` function. Next, briefly explain what the `na.rm` argument is used for.
+
+::: {.callout-tip collapse="true"}
+You can type `?mean` or `help(mean)` in R to get the documentation.
+
+The `na.rm` argument indicates whether to ignore missing values ​​(`NA`) in calculating the average (`TRUE` or `FALSE`).
+:::
+
+## Exercise 5 — Rewrite code with style
+
+Fix the following code to follow tidyverse style best practices:
+
+``` r
+x=mean(c(3,NA,5),na.rm=TRUE)
+```
+
+::: {.callout-tip collapse="true"}
+``` r
+x <- mean(c(3, NA, 5), na.rm = TRUE)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 6 — Create an HTML report
+
+Create a `rapport.qmd` file containing:
+
+- a YAML header with a title and HTML format
+
+- a block of code that displays the average of a vector
+
+::: {.callout-tip collapse="true"}
+``` markdown
+---
+title: "First report"
+format: html
+---
+
+mean(c(1, 2, 3, 4, 5))
+```
+
+\`\`\`
+:::

--- a/en/module_02/aventure.qmd
+++ b/en/module_02/aventure.qmd
@@ -1,0 +1,722 @@
+---
+title: "Adventure 2 - Github and digital data visualization"
+subtitle: "STT-1100 Introduction to Data Science"
+author: 
+  - institute: “Laval University”
+editor:visual
+editor_options: 
+  chunk_output_type: console
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    css: [../css/base_css.css]
+    self-contained: true
+# number-sections: true
+---
+
+```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+library(palmerpenguins)
+library(tidyverse)
+
+#Here are the changes I made to the penguin dataset for this adventure:
+#penguins[c(11), c("body_mass_g", "bill_length_mm")]
+
+#Adding an outlier on a single variable:
+#One individual has a flipper_length_mm of 400 mm, which is well beyond normal.
+#Added an outlier on two variables:
+#An individual has a body mass (body_mass_g) of 9000 g and a bill length (bill_length_mm) of 20 mm, an inconsistent combination.
+
+library(UlavalSSD)
+```
+
+## 🧊 Antarctic Mission – In the shoes of a data scientist
+
+Welcome to your new scientific mission! You are now a **data scientist** in the team of **Dr Adélie**, a researcher specializing in the study of Antarctic penguins. She has entrusted you with a set of data collected in the field to help her explore certain avenues of research.
+
+Your job is to **manipulate, transform and visualize** data rigorously, in order to extract useful and reproducible information. In particular, you will need to produce convincing visualizations, calculate descriptive statistics and document your approach in a clear report.
+
+> 🐧 The dataset, which contains physical measurements of several species of penguins, will serve as a field of investigation.
+
+----------------------------------------------------------------------------------
+
+## ✍️ Progress of the mission and expected deliverables
+
+The mission will take place in **two stages**, because Dr. Adélie will soon have to leave on an expedition to Antarctica.
+
+### 🔹 Part 1 – Before Dr. Adélie leaves
+
+Before her departure, you will work closely with her to explore the first avenues. She will ask you to:
+
+- Clean and transform data with `dplyr`.
+- Calculate relevant descriptive statistics on numerical variables.
+- Create exploratory visualizations (`ggplot2`) to better understand the relationships between variables.
+
+📘 **Deliverable from the first part**:\
+You must write a **logbook** in a Quarto report (HTML format) which documents your observations, your explorations and the avenues that you raised with her. This log is used to keep track of your analyzes before they go into the field. A logbook template will be given to you.
+
+----------------------------------------------------------------------------------
+
+### 🔹 Part 2 – When Dr. Adélie returns
+
+Back from her mission, Dr. Adélie will come back with **specific questions** to explore and will ask you to help her prepare a solid report to accompany her **grant application**.
+
+📘 **Deliverable of the second part**:\
+A **structured and complete report** responding to its new specific requests, including: - Targeted visualizations. - Accurate analyzes based on your previous findings. - Professional formatting (title, legends, readable axes, graphic consistency). - Rigorous monitoring via **GitHub**, including several well-commented commits. - It will give you a list of clear and precise tasks to complete.
+
+----------------------------------------------------------------------------------
+
+> 🧑‍💼 **Field note**: During your mission, a more experienced colleague (Jules Tremblay) will come see you from time to time to check that everything is going well. He or she will ask you a few **quick questions** to test your understanding. Answer them seriously, these checks will help you consolidate your learning!
+
+# How to succeed in this adventure {.unnumbered}
+
+Welcome to this new adventure in data science! This time, you will collaborate with a researcher who studies penguins at Palmer Station in Antarctica. Your mission is to explore and analyze its data to help it answer its scientific questions.
+
+To succeed in this adventure, here are some essential tips:
+
+- **Read each section carefully** before experimenting. The explanations provided will allow you to fully understand the concepts and tools used.\
+- **Actively experiment** by running the proposed code and adapting it to your own analyses. Modifying and testing different approaches is a great way to learn.\
+- **Think about the questions asked by the researcher** and use the appropriate tools to answer them. Remember to justify your choices and interpretations.\
+- **Be rigorous** in your work by adopting good programming practices and documenting your analyses.\
+- **Do not hesitate to ask questions** if you encounter difficulties or if certain concepts remain unclear.
+
+This adventure will allow you to develop your skills in data manipulation, visualization and analysis with `dplyr` and `ggplot2`. These are essential skills for a data scientist. Take the time to explore the different steps and have fun learning!
+
+# 🚀 Working on Github
+
+The researcher has prepared a repository on GitHub where she wants you to save all your work. For her part, she submitted the database she collected as well as a detailed description of the variables. In particular, she would like you to complete a model logbook in Quarto format.
+
+Before you start analyzing the data, you need to grab the GitHub repository containing the necessary files.
+
+1️⃣ Clone the "Adventure-2-IDENTIFIANT_GITHUB" repository, to do this create a new Rstudio project and copy paste the HTTPS link of your Github repo (see help sheet).
+
+💡 Tip: If you want to come back to this project later, you can open the project directly by double-clicking the `.Rproj` file in your file explorer.
+
+2️⃣ Open the Quarto logbook file: Enter your name and save.
+
+3️⃣ First commit and push to GitHub: Once your `.qmd` file has been modified and saved, commit and push your changes to GitHub:
+
+Warning: remember that commit messages must be meaningful. For example "Initializing the logbook"
+
+🎯 Congratulations! You are now ready to begin scientific analysis of penguins! 🐧🚀
+
+> 💡 Tip: Use the logbook template to complete all the analyzes of the first part of this adventure. So take a few minutes to look at the structure of the document.
+
+# 📂 Reading data
+
+The researcher has provided you with an Excel file containing the penguin data she collected. Your first mission is to **load this data into R** using the RStudio GUI.
+
+**🔹 Steps to follow**
+
+1. **Open data import menu**
+
+    - In RStudio, go to the **Environment** tab.
+
+    - Click **Import Dataset**.
+
+    - Select **From Excel...**, since the extension is `.xlsx`
+
+![Button to import data](resources/bouton_import_data.png){fig-align="center"}
+
+1. **Select file**
+
+    - In the window that opens, click **Browse...** and select the **`.xlsx`** file that you downloaded via repository cloning.
+
+2. **Adjust import settings**
+
+    - Make sure that the column headers are detected.
+
+    - Check that all variables are correctly identified (e.g. the numbers are in digital format).
+
+    - We will call the dataset `penguins_mission`, complete the information in the window.
+
+3. **Import and display data**
+
+    - Click on **Import**.
+
+    - Verify that your dataset appears in the **Environment** under the name `penguins_mission`.
+
+    *Note*: when you click on **Import,** a code is executed in the console. This is the code to import the dataset.
+
+    - To see a preview of the data, use the following command in the console:
+
+        `View(penguins_mission)`
+
+📝 **Reminder: document your import in your Quarto report**
+
+A good practice in data science is to always **document** how you imported the data, even if you used a GUI.\
+Add the code executed in the console in your **Quarto** log file **(`.qmd`)** to the appropriate section.
+
+In each analysis report, you should have a first section **Reading data,** with a code block that contains the code to read the data. I would like to take this opportunity to remind you of **good Tidyverse programming practices**, namely that in your block of code, there should for example be comments.
+
+💡 **Why is this important?**\
+This ensures that your analysis is **reproducible**: if another researcher wants to do it again, they will be able to run your code without having to use the GUI.
+
+```{r, echo=FALSE, message=FALSE, warning=FALSE}
+library(readxl) # Loading the package to read Excel
+
+# Data import
+penguins_mission <- read_excel("resources/penguins_data.xlsx")
+
+```
+
+::: {.callout-important title="🧑‍💼 Intervention by Jules – Name of the base"}
+You have just imported the Excel file. Tell me, in which variable did you store the data for the rest of the analysis?\
+1. `penguins`\
+2. `penguins_mission`\
+3. `penguin_data`\
+4. `Antarctic_mission`
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+You had to name your base **`penguins_mission`**, as indicated in the import instruction.\
+💡 Warning: the entire rest of the analysis is based on this consistent name!
+:::
+
+**📌 Once your data is loaded, you are ready to explore and analyze it 🐧! Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+# 🛠️ Data manipulation
+
+## Data summary with `glimpse()`
+
+The researcher wants a quick view of the data to check its structure. Use `glimpse()` to preview:
+
+```{r, eval=FALSE}
+library(tidyverse)
+glimpse(penguins_mission)
+```
+
+::: {.callout-important title="🧑‍💼 Jules – Numerical variables"}
+How many **numeric variables** do you see in the `glimpse()` of `penguins_mission`?\
+- 3\
+- 4\
+- 5\
+- 6
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+There are generally **4 numeric variables**:\
+`bill_length_mm`, `bill_depth_mm`, `flipper_length_mm` and `body_mass_g`.\
+🧠 Please note: some versions of the game may vary depending on import!
+:::
+
+#### 🔍 Quick view with `glimpse()`
+
+The `glimpse()` function of the **dplyr** package allows you to obtain **a quick and structured overview of a dataset**.
+
+Rather than displaying all lines or a tree structure like `str()`, `glimpse()` presents variables **horizontally**, with:
+
+- The **name of each variable**
+
+- Its **data type** (`<dbl>`, `<chr>`, `<fct>`, etc.)
+
+- Some **representative values** of each column
+
+This layout makes it easy to quickly review the structure of a table, especially when it has **many columns**.
+
+> 🧠 **Good to know**: `glimpse()` is particularly useful for spotting possible type errors (e.g. a numeric variable encoded as text) or for detecting missing values.
+
+::: callout-tip
+#### Exercise
+
+The researcher wishes to obtain an initial report on the available data. To do this, you must complete the following text and integrate it into your Quarto analysis logbook: \> "The dataset contains \*\*\_\_\_\*\* observations and \*\*\_\_\_\*\* variables. The variables are ***,***, \*\*\_\_\_\*\*....etc"
+:::
+
+::: callout-note
+💡 **Reflection question**: What happens if the researcher modifies the database? For example, she forgot a penguin and adds it without telling you, then updates the GitHub repository. When you run your analysis again in your Quarto report (`.qmd`), what will happen? 🤔
+:::
+
+Don't worry if this seems complicated! We will return to this aspect later in the session. 😉
+
+::: callout-tip
+#### Exercise
+
+How many variables are numeric? How many character types? *to-do*: Include your answer in your logbook following the blank text.
+:::
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+## Select variables with `select()`
+
+The researcher wants to focus only on certain variables relevant to her analysis. Use `select()` to keep only `species`, `island`, `bill_length_mm` and `body_mass_g`:
+
+```{r, eval=FALSE}
+penguins_subset <- penguins_mission %>% 
+  select(species, island, bill_length_mm, body_mass_g)
+```
+
+::: callout-note
+#### Example
+
+Do a `glimpse()` of the new `penguins_subset` database. Why did you choose a new name?
+:::
+
+::: callout-tip
+#### Exercise
+
+Select all variables except `flipper_length_mm` and `body_mass_g`. Be careful there is a quick way to do this!
+:::
+
+## Create new variables with `mutate()`
+
+💡 **Explanation**: The researcher wants to add a new column indicating the weight in kilograms instead of grams. Indeed, her measuring device indicated the measurements in g, but she believes that it will be easier to interpret in kg.
+
+💡 **Why is this useful?** Transforming units can make it easier to understand and communicate results.
+
+The researcher wants to add a new column indicating the weight in kilograms instead of grams. Use `mutate()` to create this new variable:
+
+```{r eval=FALSE}
+penguins_mission <- penguins_mission %>% 
+  mutate(body_mass_kg = body_mass_g / 1000)
+```
+
+::: {.callout-important title="🧑‍💼 Jules – Mass in kilograms"}
+You transformed the mass into kilograms. The mass of penguin number 21 is smaller than 4 kg, true or false?\
+1. True\
+2. False\
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+When we look at row 21 of the database, we get a number for `body_mass_kg` of 4.01 kg, so the answer is **False**.\
+
+```{r eval=FALSE}
+penguins_mission[21,"body_mass_kg"]
+```
+:::
+
+We will now continue with a new variable in which the researcher is very interested:
+
+::: callout-tip
+#### Exercise
+
+Create a new variable called `bill_ratio` corresponding to the ratio between the length and depth of the bill.
+
+🧐 **Question from the researcher**: one of my colleagues in Antarctica assures me that the **average** ratio between the length and depth of the beak is greater than 3. For my part, I find this strange, because it does not respect what we can read in the literature. Can you help me with this? I would like you to answer the question in the logbook.
+:::
+
+```{r echo=FALSE}
+penguins_mission <- penguins_mission %>% 
+  mutate(ratio = bill_length_mm/bill_depth_mm)
+```
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+## Filter data with `filter()`
+
+The researcher wants to analyze only penguins from **Biscoe** Island. Use `filter()` to keep only these observations:
+
+```{r eval=FALSE}
+penguins_biscoe <- penguins_mission %>% 
+  filter(island == "Biscoe")
+```
+
+::: callout-tip
+#### Exercise
+
+Filter the data to only keep penguins of the **Adelie** species from Biscoe Island.
+:::
+
+## Group and summarize data with `group_by()`
+
+The researcher wants to know the average mass of penguins by species. Use `group_by()` followed by `summarise()` to get this information:
+
+```{r eval=FALSE}
+penguins_summary <- penguins_mission %>% 
+  group_by(species) %>% 
+  summarise(mean_body_mass_g = mean(body_mass_g, na.rm = TRUE))
+```
+
+*Note*: we use the `na.rm=TRUE` option in functions, which is quite practical, because it allows the statistic to be calculated by omitting missing values (`NA`).
+
+::: callout-tip
+#### Exercise
+
+🧐 **Question from the researcher**: Which island/species combination has the lowest median fin length? I would like you to answer the question in the logbook.
+:::
+
+Thanks to `group_by` we can also, for example, filter by group, which can be very practical!
+
+::: callout-tip
+#### Exercise
+
+📝 **Exercise**: Bring out the first penguin from the database for each species and each island. *Hint:* you can use the `slice` function.
+:::
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+# 🐧 An emergency call from Antarctica
+
+While you are making good progress in your data analysis, you receive an urgent message from the researcher. She had to rush to Antarctica for an emergency mission: to help a colony of penguins facing extreme weather conditions.
+
+Before her departure, she took care to leave you a list of essential tasks to complete. She is counting on you to continue her analysis! However, the connection is unstable there, and the only way to communicate with her is through Teams, she will send you messages but you wouldn't be able to communicate with her.
+
+> **Note:** here you are still in part 1 of the adventure, but the researcher has left you a list of tasks to complete before she leaves. So you need to continue working on the `penguins_mission` dataset that you created previously. You must therefore continue to complete the logbook.
+
+# 📊 Data visualization
+
+Data visualization is an essential step in analysis because it provides a better understanding of trends and relationships between variables. Good visualization makes data easier to interpret and helps spot outliers or interesting patterns.
+
+💡 **Reminder of good coding practices in visualization**:
+
+- Always **label** axes with `labs()` to make graphs understandable.
+
+- Use **suitable colors** to distinguish groups without overloading the visualization.
+
+- Check that the scale of the axes is consistent and does not distort the interpretation of the data.
+
+- Adapt the **binwidth** of histograms and the **transparency** of points in scatter graphs to avoid poor readability.
+
+- Test several types of graphs before concluding on an analysis.
+
+## Histograms
+
+💡 **Explanation**: A histogram allows you to visualize the distribution of a numerical variable. Here we will for example examine the distribution of bill depths (`bill_depth_mm`).
+
+```{r}
+library(ggplot2)
+ggplot(penguins_mission, aes(x = bill_depth_mm)) +
+  geom_histogram(binwidth = 0.5, fill = "steelblue", color = "black") +
+labs(title = "Distribution of penguin beak length",
+       x = "Spout length (mm)",
+       y = "Staff")
+```
+
+::: callout-note
+#### Example
+
+Change the value of `binwidth` in the code above and see how it changes the histogram.
+:::
+
+::: {.callout-important title="🧑‍💼 Jules – Observed distribution"}
+When you look at the histogram of `bill_depth_mm`, which word best describes the shape of the distribution?\
+1. Uniform\
+2. Bimodal\
+3. Asymmetrical right\
+4. Symmetric
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+The distribution is generally **symmetric**, even slightly spread out.\
+A good visual reading helps to anticipate central and extreme measurements.
+:::
+
+**📜 Instructions left by the researcher**
+
+To find out the researcher's first request, here is the message she received:
+
+```{r eval=TRUE, echo=FALSE}
+consult_stains("histogram")
+```
+
+::: callout-tip
+#### Exercise
+
+Create a histogram for the `flipper_length_mm` variable. You must adjust all the information on the graph while respecting good visualization practices.
+
+🧐 **Question from the researcher**: Looking at the histogram of fin length, do you notice anything particular in the distribution?
+:::
+
+Let's take the visualization a little further to try to answer his request.
+
+## Boxplot
+
+💡 **Explanation**: A boxplot allows you to visualize the dispersion of a numerical variable and to identify possible outliers. Here we will look at the distribution of fin length (`flipper_length_mm`).
+
+```{r}
+ggplot(penguins_mission, aes(x = species, y = flipper_length_mm, fill = species)) +
+  geom_boxplot() +
+  labs(title = "Distribution of fin length by species",
+       x = "Species",
+       y = "Fin length (mm)")
+```
+
+::: callout-note
+#### Example
+
+Add a variable to differentiate between islands and see if some islands have more extreme values.
+:::
+
+::: callout-tip
+#### Exercise
+
+Find the row number of the observation that appears to be an outlier in fin length.
+:::
+
+::: {.callout-important title="🧑‍💼 Jules – Abnormal observation"}
+What is the **line number** of the observation that has a **400 mm fin** (outlier added on purpose)?\
+1. 1\
+2. 11\
+3.6\
+4. 113
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+The outlier is **line 6**.\
+It was added on purpose to test your ability to visually detect anomalies.
+:::
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+::: callout-tip
+#### Exercise (optional)
+
+In the previous graph, the legend title is "species", which is by default the name of the variable. Change it to “Species” in English. You have to figure out for yourself how to do this.
+:::
+
+## Scatter plots
+
+💡 **Explanation**: A scatter plot (or cloud of points) allows you to visualize the relationship between two numerical variables. Here we will look at the relationship between bill length (`bill_length_mm`) and bill depth (`bill_depth_mm`).
+
+```{r}
+ggplot(penguins_mission, aes(x = bill_length_mm, y = bill_depth_mm)) +
+  geom_point() +
+  labs(title = "Relationship between beak length and depth",
+       x = "Spout length (mm)",
+       y = "Spout depth (mm)")
+```
+
+::: callout-note
+#### Example
+
+Add a color variable to differentiate between islands and see if some islands have different relationships.
+:::
+
+To find out the researcher's next request, here is the message you just received:
+
+```{r eval=TRUE, echo=FALSE}
+consult_spots("point_cloud")
+```
+
+::: callout-tip
+#### Exercise
+
+Modify the scatter plot to display the relationship desired by the researcher. Do you find that one point looks weird? If yes, what is its line number?
+:::
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+# 🧮 Descriptive statistics
+
+💡 **Explanation**: Descriptive statistics allow you to quickly summarize and understand a set of data. They are divided into several categories:
+
+- **📌 Central tendency**: average, median
+- **📌 Dispersion**: variance, standard deviation, coefficient of variation
+- **📌 Distribution**: min, max, quartiles
+- **📌 Asymmetry and kurtosis**: skewness and kurtosis (optional)
+
+We will see how to obtain these statistics in R with `dplyr`. Using the `summarise` function it is very easy to calculate descriptive statistics on a variable:
+
+```{r eval=FALSE}
+penguins_mission %>%
+  summarize(
+    mean_bill_length = mean(bill_length_mm, na.rm = TRUE), # average
+    median_bill_length = median(bill_length_mm, na.rm = TRUE), # median
+    sd_bill_length = sd(bill_length_mm, na.rm = TRUE), # standard deviation
+    var_bill_length = var(bill_length_mm, na.rm = TRUE), # variance
+    min_bill_length = min(bill_length_mm, na.rm = TRUE), # min
+    max_bill_length = max(bill_length_mm, na.rm = TRUE), # max
+    q1_bill_length = quantile(bill_length_mm, 0.25, na.rm = TRUE), # Q1
+    q3_bill_length = quantile(bill_length_mm, 0.75, na.rm = TRUE) #Q3
+  )
+```
+
+**📜 Instructions left by the researcher**
+
+To find out the researcher's first request, she has just sent you this:
+
+```{r echo=FALSE}
+consult_stains("descriptive_statistics")
+```
+
+::: callout-tip
+#### Exercise
+
+Respond precisely in your logbook to Doctor Adélie’s request.
+:::
+
+✅ Quick method with `across()` and `dplyr`
+
+You can apply all statistical functions on several columns at once:
+
+```{r eval=FALSE}
+penguins_mission %>%
+  group_by(species) %>%
+  summarize(across(bill_length_mm, list(
+    mean = mean, median = median, sd = sd, var = var, 
+    min = min, max = max, q1 = ~quantile(.x, 0.25), q3 = ~quantile(.x, 0.75)
+  )))
+
+
+```
+
+💡 Advantages:
+
+- Less code repetition
+
+- Easily expandable to multiple variables by changing `bill_length_mm` to `c(bill_length_mm, flipper_length_mm)`
+
+::: {.callout-important title="🧑‍💼 Jules – Average ratio value"}
+You calculated `bill_ratio` above with the `mutate` function. If the average is 2.94 and your colleague expects 3.5, what can you conclude?\
+1. The colleague is right, 2.94 ≈ 3.5\
+2. More samples are needed\
+3. Your results contradict his hypothesis\
+4. The ratio is not useful
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+An average of **2.94**, much lower than 3.5, contradicts the colleague's hypothesis.\
+This suggests a difference, but you could also compare the distributions, for example with a histogram or a boxplot, to better visualize the variations.
+:::
+
+## Advanced visualization and descriptive statistics (optional)
+
+We will now create a detailed boxplot which displays:
+
+- Quartiles (Q1-Q3)
+- The median
+- The average
+- Extreme values
+
+::: callout-tip
+#### Exercise
+
+Which of the above statistics is not usually displayed in a boxplot? 🤔
+:::
+
+Before leaving for Antarctica, the researcher left you a piece of code (presumably a start of work she wanted to do);
+
+```{r eval=TRUE}
+ggplot(penguins_mission, aes(x = species, y = bill_length_mm, fill = species)) +
+  geom_boxplot(alpha = 0.5) +
+  stat_summary(fun = mean, geom = "point", shape = 23, size = 4, fill = "red") +
+  labs(title = "Beak length of penguins by species",
+       x = "Species",
+       y = "Spout length (mm)") +
+  theme_minimal()
+```
+
+**📜 Instructions left by the researcher**
+
+To find out the optional task of the researcher:
+
+```{r echo=FALSE}
+consult_stains("Visualization_descriptive_statistics")
+```
+
+::: callout-tip
+#### Exercise
+
+Complete Dr. Adélie's `ggplot2` code to answer her request. Include this in your logbook. Tell us how this advanced chart can help us better understand our data.
+:::
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+🎯 Congratulations! You have now completed part 1 of this adventure, you can go and rest a little before the next part of this mission! 🐧🚀
+
+::: {.callout-important title="🧑‍💼 Jules – When to commit?"}
+When should you make a Git commit?\
+1. Once at the very end of the project\
+2. Each time you add a chart\
+3. Regularly after each important step\
+4. Only after a mistake
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Jules"}
+You must make a commit **after each significant step** (import, filter, graph, analysis).\
+🧠 This ensures traceability, and will save you stress if you have to go back.
+:::
+
+# 🐧 The return of Dr Adélie Fortier! (2nd part of the adventure)
+
+🔎 After several weeks in Antarctica observing penguins, our researcher is back with lots of new questions in mind. She noticed that some species seemed to have very distinct characteristics, but she would like a more in-depth analysis which will help her obtain a new grant for her research project.
+
+📘 **Reminder of the deliverables of the second part**:\
+A **structured and complete report** responding to its new specific requests, including:
+
+- Targeted visualizations.
+
+- Accurate analyzes based on your previous findings.
+
+- Professional formatting (title, legends, readable axes, graphic consistency).
+
+- Rigorous monitoring via **GitHub**, including several well-commented commits.
+
+- It will give you a list of clear and precise tasks to complete.
+
+> **Note**: you must create your quarto report yourself to help them with their grant application. Start by creating a new QMD report.
+
+His main question: 👉 ​​How do the physical characteristics of penguins vary depending on the species?
+
+To help him, you will carry out a complete analysis, mobilizing all the skills acquired in this module.
+
+::: callout-tip
+#### 📌 Question 1
+
+Are there any notable differences between penguin species?
+:::
+
+➡️ To answer it, you need to explore the differences between the physical characteristics of the three species.
+
+✅ Tasks:
+
+Calculate the mean and standard deviation of the following variables by species:
+
+- Bill length (`bill_length_mm`)
+
+- Bill depth (`bill_depth_mm`)
+
+- Fin length (`flipper_length_mm`)
+
+- Body mass (`body_mass_g`)
+
+Display the results in clear tabular form.
+
+💡 Hint: Use `group_by()` and `summarise()` from `dplyr` to get these statistics.
+
+::: callout-tip
+#### 🔬 Question 2
+
+Can we identify an indicator of the penguin's "*size*"?
+:::
+
+➡️ The researcher would like a new variable that could represent the overall size of a penguin.
+
+✅ Tasks:
+
+- Create a new variable **`index_grandeur`**, defined as the sum of:
+
+    - The length of the fins (flipper_length_mm)
+
+    - The length of the bill (bill_length_mm)
+
+- Add this variable to the dataset and display some values to verify its calculation.
+
+💡 Hint: Use `mutate()` to add the variable to your data.frame.
+
+::: callout-tip
+#### 🔬 Question 3
+
+How are these characteristics distributed among species?
+:::
+
+➡️ To better visualize the differences between species, the researcher asks you to create graphs.
+
+✅ Tasks:
+
+- A histogram of bill length (`bill_length_mm`) by species.
+
+- A scatterplot showing the relationship between **`index_size`** and body mass (`body_mass_g`), coloring by species.
+
+Be careful, don't forget your good visualization practices.
+
+**✍️ Conclusion**
+
+- What do you notice?
+
+- What are the most striking differences between species?
+
+**Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀**
+
+----------------------------------------------------------------------------------
+
+🎯 **Mission succeeded!** You have successfully helped Dr Adélie Fortier analyze the penguin data! 🚀

--- a/en/module_02/plan_apprentissage.qmd
+++ b/en/module_02/plan_apprentissage.qmd
@@ -1,0 +1,376 @@
+---
+title: "Module 2 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# Module objectives
+
+At the end of this module, you should be able to
+
+- Use GitHub via RStudio to clone a repository and make commits and pushes.
+
+- Read an `xls` file in RStudio.
+
+- Manage and transform digital data using `dplyr` (`glimpse`, `select`, `mutate`, `filter`).
+
+- Calculate and interpret descriptive statistics for numerical variables (`mean`, `median`, `standard deviation`, `variance`, `range`, `quantiles`), including for subgroups of data.
+
+- Visualize numerical variables with `ggplot2` (`histogram`, `box plot`, `scatter plot`) and interpret the resulting graphs.
+
+- Produce and interpret graphs comparing the distribution of continuous variables between groups (`superimposed histograms`, `juxtaposed box plots`, `stacked densities (ridge plots)`, `facet visualization`).
+
+- Use `ggplot2` options to improve the quality of graphs (titles, legends, readable axes, graphic consistency, `facets`).
+
+# Initial readings
+
+As module 2 is spread over 2 weeks, there is a little more reading, to prepare yourself for the first part of the module you can skim the readings and come back to them in more detail in preparation for part 2.
+
+We start with a few chapters in the famous R4DS by Hadley Wickham and Garrett Grolemund:
+
+- [Data visualization](https://r4ds.hadley.nz/data-visualize.html){target="_blank"}\
+    *Learn how to use `ggplot2` to create your first graphs. This introduction to data visualization shows you how to effectively represent numerical variables and how to customize your charts.*
+
+- [Data transformation](https://r4ds.hadley.nz/data-transform.html){target="_blank"}\
+    *Learn how to transform your datasets with `dplyr`: filter, sort, create new columns and summarize information. This chapter lays the foundation for tidyverse-style data manipulation.*
+
+- [Exploratory Data Analysis (EDA)](https://r4ds.hadley.nz/EDA.html){target="_blank"}\
+    *Explore your data to identify trends, detect extreme values and formulate hypotheses. This chapter presents simple but powerful techniques for visual and statistical analysis.*
+
+- [Tidy data (spreadsheets)](https://r4ds.hadley.nz/spreadsheets.html){target="_blank"}\
+    *Find out how to organize your data to make it actionable. This chapter discusses the concept of "clean data" and shows you how to recognize common table structures in Excel or CSV files.*
+
+### 📐 Tidyverse Style Guide
+
+- [Best practices for visualization with ggplot2 (Tidyverse Style Guide)](https://style.tidyverse.org/ggplot2.html){target="_blank"}\
+
+### 📗 A new reference book
+
+In this module, we introduce a second reference work: **Introduction to Modern Statistics** (*by Mine Çetinkaya-Rundel and Johanna Hardin*).
+
+> Note: we will often abbreviate with **IMS**
+
+This book, also available free online, offers a **modern and applied approach to statistics**. It emphasizes visualization, statistical intuition and best practices in data science. It constitutes an excellent complement to R4DS, in particular for deepening the statistical aspects of exploratory analyses.
+
+- [Introduction to Modern Statistics – Chapter 5: Exploring numerical data](https://openintro-ims.netlify.app/explore-numerical){target="_blank"}\
+    *In this chapter, you will learn how to explore numerical data using statistical tools like numerical summaries, histograms, and boxplots. It offers a clear and rigorous vision of data distribution.*
+
+# Adventure
+
+[Adventure 2](aventure.qmd)
+
+# Challenge
+
+Here is the challenge you will have to complete for **module 2**. It is divided into two parts:
+
+**Part 1**: Complete your logbook and submit it to GitHub. Ten (10) logbooks will be selected at random and will be subject to a **summative evaluation**.
+
+**Part 2**: Submit the **data analysis report** on GitHub that Dr. Adélie can use as part of her grant application.
+
+# Consolidation exercises
+
+To put into practice what you have learned from this module, you will find below **13 exercises** covering all the concepts of module 2 (`ggplot2`, `dplyr`, EDA, tidy data, good style practices and *IMS* style descriptive statistics).\
+We will mainly use the **`mpg`** dataset from the `ggplot2` library (performance of cars sold in the United States, 1999‑2008). When other datasets are used, they are specified in the statement.
+
+### Dataset `mpg` – Description of variables
+
+| Variable | Type | Description |
+|-----------------|-----------------|--------------------------------------|
+| `manufacturer` | character | Car manufacturer (e.g. *toyota*, *audi*). |
+| `model` | character | Specific vehicle model (e.g. *corolla*, *a4*). |
+| `displ` | numeric | Engine displacement in liters (L). |
+| `year` | integer | Model year (1999 or 2008). |
+| `cyl` | integer | Number of engine cylinders. |
+| `trans` | character | Transmission type: automatic (`auto`) or manual (`manual`). |
+| `drv` | character | Final drive type: front-wheel drive (`f`), rear-wheel drive (`r`) or all-wheel drive (`4`). |
+| `cty` | numeric | **City** consumption in miles per gallon (MPG). |
+| `hwy` | numeric | **Highway** consumption in miles per gallon (MPG). |
+| `fl` | character | Fuel type: *c* (CNG), *d* (diesel), *e* (ethanol), *p* (premium), *r* (regular). |
+| `class` | character | Vehicle category: *compact*, *suv*, *minivan*, etc. |
+
+> ℹ️ Source: EPA *Fuel Economy* database, included in **ggplot2** and documented with `?mpg`.
+
+----------------------------------------------------------------------------------
+
+## Exercise 1 — First graph *(quick view)*
+
+*Context:* you discover the relationship between engine capacity (`displ`) and highway consumption (`hwy`) in **`mpg`**. Draw a scatterplot.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(tidyverse)
+
+mpg %>% 
+  ggplot(aes(displ, hwy)) +
+  geom_point() +
+  labs(
+    title = "Highway consumption vs displacement",
+    x = "Cylinder capacity (L)",
+    y = "Highway MPG"
+  )
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 2 — Adding color and theme *(aesthetic)*
+
+*Context:* improve the readability of the previous graph by distinguishing points by **vehicle category** (`class`) and applying a minimalist theme.
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  ggplot(aes(displ, hwy, color = class)) +
+  geom_point(alpha = 0.8, size = 2) +
+  theme_minimal() +
+  labs(
+    title = "Consumption according to category",
+    color = "Category"
+  )
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 3 — Filter with `dplyr` *(targeted extraction)*
+
+*Context:* the marketing manager of **Toyota** wants to know the dispersion of its models. Select only *Toyota* cars and display `model`, `displ`, `hwy`.
+
+::: {.callout-tip collapse="true"}
+``` r
+toyota <- mpg %>% 
+  filter(manufacturer == "toyota") %>% 
+  select(model, displ, hwy)
+
+toyota
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 4 — Derived variable and summary *(descriptive statistics)*
+
+*Context:* we define a measure of **overall efficiency** `efficiency = hwy / cty`. Calculate, by category (`class`), the mean and standard deviation of this new variable.
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  mutate(efficiency = hwy / cty) %>% 
+  group_by(class) %>% 
+  summarize(
+    eff_mean = mean(efficiency, na.rm = TRUE),
+    eff_sd = sd(efficiency, na.rm = TRUE)
+  )
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 5 — Histogram and density *(distribution)*
+
+*Background:* You are intrigued by the displacement distribution. Plot the histogram of `displ` (class width 0.5L) and overlay the density.
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  ggplot(aes(displ)) +
+  geom_histogram(binwidth = 0.5, fill = "steelblue", color = "white") +
+  geom_density(aes(y = ..count.. * 0.5), linewidth = 1) +
+  labs(x = "Displacement (L)")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 6 — Extreme value *(outlier identification)*
+
+*Context:* a magazine wants to know which model has the **best highway consumption**. Find it and display `manufacturer`, `model`, `year`, `hwy`.
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  filter(hwy == max(hwy)) %>% 
+  select(manufacturer, model, year, hwy)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 7 — Best practices #1 *(tidyverse style)*
+
+*Background:* you receive a sloppy script. Rewrite it to follow the tidyverse style guide.
+
+- First run the code to see what it gives. \> This is the old way of making a graph with `base R`.
+
+- Reproduce the graph with `ggplot2` respecting good style practices.
+
+``` r
+plot(mpg$displ,mpg$hwy,col=as.factor(mpg$drv));title("plot")
+```
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  ggplot(aes(displ, hwy, color = drv)) +
+  geom_point() +
+  labs(
+    title = "Highway consumption vs displacement",
+    x = "Cylinder capacity (L)",
+    y = "Highway MPG",
+    color = "Transmission"
+  )
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 8 — Best practices #2 *(script structure)*
+
+*Context:* create a file `analyse_mpg.R` with:
+
+- a clear header (author, date);
+
+- loading `tidyverse`;
+
+- a pipeline that calculates the average of `hwy` by `class` and saves it in `mean_hwy`.
+
+::: {.callout-tip collapse="true"}
+``` r
+#analyse_mpg.R – A. Nicosia
+# Date: 2025‑05‑20
+
+library(tidyverse)
+
+mean_hwy <- mpg %>% 
+  group_by(class) %>% 
+  summarize(mean_hwy = mean(hwy, na.rm = TRUE))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 9 — “tidy” data *(pivot_longer)*
+
+*Context:* you are moving annual sales from wide to long format for easier visualizations.
+
+``` r
+dirty <- tibble(
+  brand = c("A", "B"),
+  sales_2023 = c(120, 95),
+  sales_2024 = c(150, 110)
+)
+```
+
+::: {.callout-tip collapse="true"}
+``` r
+sales_long <- dirty %>% 
+  pivot_longer(
+    cols = starts_with("sales_"),
+    names_to = "year",
+    names_prefix = "sales_",
+    values_to = "units"
+  )
+
+sales_long
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 10 — Numerical summary *(five‑number)*
+
+*Context:* quick statistical summary of city MPG (`cty`).
+
+::: {.callout-tip collapse="true"}
+``` r
+fivenum(mpg$cty)
+# or
+summary(mpg$cty)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 11 — Boxplot by category *(comparison of groups)*
+
+*Context:* visualize the distribution of `hwy` by `class`, classes sorted by decreasing median.
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  ggplot(aes(x = reorder(class, hwy, median, na.rm = TRUE), y = hwy)) +
+  geom_boxplot(fill = "orange") +
+  coordinate_flip() +
+  labs(
+    x = "Category (sorted)",
+    y = "Highway MPG"
+  )
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 12 — Facets *(transmission distribution)*
+
+*Context:* compare displacement distributions (`displ`) according to transmission type (`drv`).
+
+::: {.callout-tip collapse="true"}
+``` r
+mpg %>% 
+  ggplot(aes(displ)) +
+  geom_histogram(binwidth = 0.5, fill = "darkseagreen") +
+  facet_wrap(~ drv, nrow = 1) +
+  labs(x = "Displacement (L)")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## Exercise 13 — Complete statistical analysis *(IMS inspiration)*
+
+*Background:* As in Chapter 5 of *Introduction to Modern Statistics*, you need to explore the **`hwy`** variable in depth.
+
+1. Calculate the mean, standard deviation, median, IQR and number of observations.
+2. Create a histogram of `hwy` with density overlaid.
+3. Add a (horizontal) boxplot below the histogram.
+4. Interpret: symmetric or asymmetric distribution? extreme values? What can we conclude about the energy efficiency of cars?
+
+::: {.callout-tip collapse="true"}
+``` r
+#1. Statistics
+mpg %>% 
+  summarize(
+    n = n(),
+    mean_hwy = mean(hwy),
+    sd_hwy = sd(hwy),
+    median_hwy = median(hwy),
+    IQR_hwy = IQR(hwy)
+  )
+
+#2‑3. Histogram + boxplot
+library(patchwork) # for assembly (optional)
+
+p1 <- mpg %>% 
+  ggplot(aes(hwy)) +
+  geom_histogram(binwidth = 2, fill = "steelblue", color = "white") +
+  geom_density(aes(y = ..count.. * 2), linewidth = 1) +
+  labs(title = "Highway MPG Distribution")
+
+p2 <- mpg %>% 
+  ggplot(aes(y = hwy)) +
+  geom_boxplot(fill = "orange", width = 0.4) +
+  theme_void()
+
+p1 / p2 # patchwork stacks both graphics
+```
+
+*Interpretation:* the distribution is slightly right-skewed; a few very efficient vehicles (\>40 MPG) appear as outliers. Overall, the median around 24 MPG indicates that a majority of cars remain moderately efficient.
+:::

--- a/en/module_03/aventure.qmd
+++ b/en/module_03/aventure.qmd
@@ -1,0 +1,548 @@
+---
+title: "Adventure 3 - Violations in Montreal restaurants"
+subtitle: "STT-1100 Introduction to Data Science"
+author: 
+  - institute: “Laval University”
+editor:visual
+editor_options: 
+  chunk_output_type: console
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    css: [../css/base_css.css]
+    self-contained: true
+# number-sections: true
+---
+
+```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+library(tidyverse)
+library(UlavalSSD)
+```
+
+# 🎬 Scenario: Become a *data journalist*
+
+You are hired as a **data journalist** by *Le Courrier Gourmand*, a fictional local media outlet that publishes interactive surveys on food in Montreal. Your editor-in-chief wants an article enlightening the public on **food offenses committed in Montreal restaurants**. She gives you some food for thought:
+
+- What is the proportion of establishments from the city of Montreal?
+
+- What are the most common violations?
+
+- What types of establishments are affected?
+
+- What amount of fines were imposed on average? Does this amount depend on the type of offense?
+
+At the end of the adventure, you will have to submit **a Quarto article** (HTML) answering these questions and illustrated with graphics constructed in R.
+
+::: callout-note
+**Your municipal ally**\
+This is **Alexandre**, municipal councilor responsible for food hygiene at the City of Montreal. It follows your investigation step by step and will ask you, at key moments, questions to guide your analyses. It is a valuable ally for writing your article, but it also has its requirements. He expects you to provide him with clear and precise answers, accompanied by relevant graphics.
+:::
+
+## Adventure objectives
+
+- Import and clean a real categorical dataset (food offenses).
+- Build frequency tables, descriptive statistics and visualizations
+- Write a short journalistic post reproducible in Quarto.
+
+::: note
+💡 **Note for report**\
+Throughout the analysis, you must keep these questions in mind and answer them in an argumentative manner in your `qmd` report.
+:::
+
+In this module, you will explore a **dataset** that describes various violations, their fines, and the type of establishments involved. Your mission: **analyze data to meet the objective of identifying offenses in restaurants in Montreal**.
+
+----------------------------------------------------------------------------------
+
+# 🎯 How to succeed in the adventure
+
+1. **Load data**: You can either:
+    - Load the `UlavalSSD` package and call `data(listecondamnation)`.
+2. **Follow the sections**: Each section contains explanations, a demonstration, experiments to carry out, then exercises.
+3. **Document your findings**: As in the previous adventures, comment on your code, explain your choices and validate your analyses. Your findings will help you write your newspaper article.
+
+----------------------------------------------------------------------------------
+
+# 🚀 Working on Github
+
+Before you start analyzing the data, you need to grab the GitHub repository containing the necessary files.
+
+1️⃣ Clone the "Adventure-3-IDENTIFIANT_GITHUB" repository, to do this create a new Rstudio project and copy paste the HTTPS link of your Github repo (see help sheet).
+
+💡 Tip: If you want to come back to this project later, you can open the project directly by double-clicking the `.Rproj` file in your file explorer.
+
+2️⃣ Adjust the Quarto file: The journal article template is present in the repository. Go write your name.
+
+3️⃣ First commit and push to GitHub: Once your `.qmd` file is adjusted and saved, commit and push your changes to GitHub:
+
+Warning: remember that commit messages must be meaningful. For example "Added my name to the article"
+
+🎯 Congratulations! You are now ready to start analyzing! 🚀
+
+# 🏷️ Categorical variables: the basics in R with `stringr`
+
+## ✨ Explanations
+
+In R, a categorical variable is often represented by:
+
+- A **factor** (`factor`) which contains a set of defined levels.
+
+- Or a simple **character** for character strings.
+
+**In the Tidyverse**, we often manipulate character strings via the **stringr** package; for conversion to factor, we can use `as.factor()` or the **forcats** package.
+
+For module 3, we will focus on categorical variables of type **character**. In Module 4, we will look at the factors in more detail.
+
+Here are examples demonstrating how to use `stringr` (part of the `Tidyverse`) to manipulate character variables in a dataset like `convictionlist`. The examples below target common cases: pattern detection, extraction, replacement, and string cleaning.
+
+## 🚀 Demonstration
+
+We will use the `listecondemnation` dataset from the `UlavalSSD` library which contains the convictions of food establishments in Quebec.
+
+```{r}
+library(UlavalSSD)
+library(tidyverse)
+glimpse(convictionlist)
+```
+
+> **Note**: Running `glimpse()` on your data will allow you to identify which columns are in `chr` (character) and which are in `factor` or even in `numeric`.
+
+> **Note 2**: Three columns are in date format, for the moment, we will not take this into account, we will come back to the date format in a module later.
+
+::: callout-tip
+#### Exercise
+
+What is the type of the `Fine` variable? Does this seem problematic to you?
+:::
+
+> This information will be relevant for cleaning the `Fine` variable in the following section, so you can document it in the Methodology section of the article.
+
+::: {.callout-important title="🧑‍💼 - Question from Alexandre"}
+*“How many offense reports appear in the raw file? »*
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Alexandre"}
+**Possible answer**: Use `nrow(listecondemnation)` after import; for example we obtain **1,712** lines.
+
+Alexandre reminds you that `?listecondemnation` gives you the documentation of the dataset.
+:::
+
+### Pattern detection (`str_detect()`)
+
+To check if the address mentions `"MONTREAL"` (or a postal code, etc.), you can do:
+
+```{r}
+
+# Create a Boolean column 'est_montreal'
+condemnationlist <- condemnationlist %>%
+  mutate(est_montreal = str_detect(Address_place_offense, "MONTREAL"))
+
+# Overview
+condemnationlist %>%
+  select(Address_place_offense, est_montreal) %>%
+  head(10)
+```
+
+You get `TRUE/FALSE` depending on the presence of the word **MONTREAL** in the string.
+
+::: callout-tip
+#### Exercise
+
+What is the proportion of the number of addresses containing the word **MONTREAL**?
+:::
+
+::: {.callout-important title="🧑‍💼 - Message from Alexandre"}
+**Message from Alexandre**: *“This is a very interesting fact to put in your article!”*
+:::
+
+### Replacement (`str_replace()` and `str_replace_all()`)
+
+To clean up the `Fine` column, you can remove the `$` symbol or replace commas with periods, etc.
+
+```{r}
+
+# str_replace() replaces the 1st occurrence; str_replace_all() all occurrences  
+condemnationlist <- condemnationlist %>% mutate( 
+  # Example: remove the $ if present 
+  Fine_clean = str_replace_all(Fine, "\\$", ""), 
+  # replace any commas with a period   
+  Amende_clean = str_replace_all(Amende_clean, ",", ".") )  
+
+# Let's check 
+condemnationlist %>%  
+  select(Fine, Fine_clean) %>%  
+  head(10)
+```
+
+Here, the patterns are **regular expressions**.
+
+- `\\$` literally matches the sign `$`.
+
+- `,` is replaced by `.` (useful if your text includes `\"1,000\"`).
+
+::: callout-tip
+#### Exercise
+
+What is the type of the `Amende_clean` variable? Is this a problem?
+:::
+
+::: {.callout-important title="🧑‍💼 - Message from Alexandre"}
+*“Not so easy to have the Fine column in digital!”*
+:::
+
+### Pattern extraction (`str_extract()`)
+
+To extract a specific element. For example, if `Address_lieu_offense` contains a postal code of the form `H2X 3E4`, we can try:
+
+```{r}
+
+condemnationlist <- condemnationlist %>%   
+  mutate(     
+    postal_code = str_extract(Offense_location_address, "[A-Z][0-9][A-Z]\\s*[0-9][A-Z][0-9]") )  
+
+condemnationlist %>%  
+  select(Address_place_offense, postal_code) %>%
+  head(10)
+```
+
+The pattern `[A-Z][0-9][A-Z]\\s*[0-9][A-Z][0-9]` is a simplified form of a Canadian postal code.
+
+::: callout-tip
+#### Exercise
+
+All postal codes that start with H2X correspond to addresses in the Ville-Marie district of Montreal.
+
+How many establishments in the Ville-Marie district have received a commission?
+:::
+
+::: {.callout-important title="🧑‍💼 - Message from Alexandre"}
+*“We have always mentioned that less than 1% of establishments in violation in Montreal come from Ville-Marie! Is this really true?”*
+
+A nice addition to your article!
+:::
+
+### Formatting (`str_to_lower()`, `str_to_upper()`, etc.)
+
+Sometimes it is useful to harmonize the case (`MONTREAL`, `Montréal`, etc.):
+
+```{r}
+condemnationlist <- condemnationlist %>%  
+  mutate(Address_lower = str_to_lower(Address_place_offense),    
+              # or str_to_upper, str_to_title ...   
+              # trim to remove excess spaces    
+              Address_trim = str_trim(Address_place_offense) )
+```
+
+### Removing multiple spaces (`str_squish()`)
+
+If the data contains unnecessary spaces:
+
+```{r}
+condemnationlist <- condemnationlist %>%   
+  mutate(     
+    Squish_address = str_squish(offense_location_address)  
+    )
+```
+
+`str_squish()` reduces all repeated spaces to one and removes those at the start/end of the string.
+
+::: callout-tip
+#### Exercise
+
+1. **Filter Montreal**: Create a new data frame `condamnation_mtl` containing **only** restaurants from Montreal. We will use the postal code here, in fact, all postal codes in Montreal start with the letter H.
+
+> **Hint**: You can use `str_sub()` to extract the first letter (or character) of a character string.
+
+2. **Keyword research**:
+
+- Detect the keyword (“TEMPERATURE”) in `SOC_NOM_ARTCL_INFRC`. Create a Boolean variable `est_temp`. This will allow us to see which infractions are related to temperature.
+
+- What is the proportion of violations related to temperature in the subset of Montreal?
+
+3. We finish cleaning the fine column.
+
+- **Complete cleaning of the `Fine` variable**: Create a variable `Amende_num` which is of type `numeric` with the amount of the fine paid by the restaurant. You will have to use the `as.numeric` function.
+
+- What is the type of the `Amende_num` variable? Is this a problem?
+
+- What is the average fine amount for temperature-related violations?
+:::
+
+::: {.callout-important title="🧑‍💼 - Question from Alexandre"}
+*“The `SOC_NOM_ARTCL_INFRC` column gives the classification of the offense. How many different types of violations do we have related to temperature”*
+
+- 1
+
+- 2
+
+- 3
+
+- 4
+
+- 5
+
+- 6
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Alexandre"}
+**Possible answer**: Use `unique()` to count the number of offense types. For example, `length(unique(listecondamnation$SOC_NOM_ARTCL_INFRC))` will give you the total number of offense types.
+
+Now we can do the same thing but for offenses related to temperature with `listecondemnation %>% filter(est_temp == TRUE) %>% unique()`
+
+And there are 5 of them:
+
+```{r echo=FALSE}
+condemnationlist %>% 
+  mutate(est_temp = str_detect(SOC_NOM_ARTCL_INFRC, "TEMPERATURE")) %>%
+  filter(est_temp == TRUE) %>%
+  select(SOC_NOM_ARTCL_INFRC) %>% 
+  unique() 
+```
+:::
+
+Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀
+
+::: {.callout-important title="🧑‍💼 - Note from Alexandre"}
+We worked on temperature-related infractions, but there are other types of infractions. Can you find one that worries you? For example, insects, rodents or unsanitary conditions!
+
+I think it could make a nice addition of key results to put in your article 😉
+:::
+
+----------------------------------------------------------------------------------
+
+# 🏗 Descriptive statistics for categorical variables
+
+In this section, we will discover how to summarize the information contained in qualitative variables, also called categorical. We will see how to count the occurrences of each category (frequency tables), calculate proportions (or percentages) in order to better visualize the distribution, and associate several variables to better understand their interactions (contingency tables). The objective is to have a clear portrait of the distribution of categories to draw quick conclusions on trends or anomalies present in the data.
+
+## ✨ Explanations
+
+**Frequency tables** and **trend measures** (number of observations, percentages) are a good starting point for summarizing categorical variables.
+
+## 🚀 Demonstration
+
+```{r}
+# Number of offenses by type of establishment
+
+condemnationlist %>%
+  count(Type_establishment) %>%
+  arrange(desc(n))
+```
+
+> **Tip**: `count()` + `arrange(desc(n))` allows you to sort the categories in order of occurrence.
+
+::: callout-tip
+#### Exercise
+
+1. **Proportions**: Calculate the proportion of each type of establishment (e.g. `count(Type_establishment) %>% mutate(prop = n / sum(n))`).
+
+2. **Average fine**: After extracting the numerical value from the `Fine` column from the exercise in the previous section, group by `Type_establishment` and calculate the average of the fine (`mean(Amende_num)`).
+
+3. **Infringements throughout Quebec**: Compare the distribution between “Montreal” (previously filtered) and the rest. Which category of establishments seems most affected?
+:::
+
+::: {.callout-important title="🧑‍💼 - Note from Alexandre"}
+We always thought that Montreal was not the worst place for food offenses regardless of the type of restaurant. Can you prove it with your results?
+:::
+
+A contingency table (or cross-tabulation) is a table which simultaneously presents the distribution of two (or more) categorical variables, thus making it possible to identify links or trends between them. For example, to cross-reference the type of establishment and the nature of the offense in your dataset:
+
+```{r eval=FALSE}
+table(
+  convictionlist$Type_establishment,
+  convictionlist$SOC_NOM_ARTCL_INFRC
+)
+
+```
+
+::: {.callout-important title="🧑‍💼 - Question from Alexandre"}
+Are there more restaurants that have been fined for `INSECT RODENT EXCREEMENT` or Rest. fast service who were fined for `UNSALUBRITY`?
+:::
+
+::: {.callout-caution collapse="true" title="✅ Response from Alexandre"}
+You can easily find the information by looking for it directly in the crosstab:
+
+```{r}
+tab <-table(
+  convictionlist$Type_establishment,
+  convictionlist$SOC_NOM_ARTCL_INFRC
+)
+
+tab["QUICK SERVICE RESTAURANT", "UNSALUBRITY"]
+
+tab["RESTAURANT", "INSECTS RODENT EXCREEMENT"]
+```
+:::
+
+We will end this section with an exercise that will allow you to familiarize yourself with contingency tables and descriptive statistics, but above all allow the city to check if their coding of the offense is correct.
+
+::: callout-tip
+#### Exercise
+
+1. **Contingency table**: Construct a cross-table between `Type_establishment` and the nature of the offense (`SOC_NOM_ARTCL_INFRC`), in your subset of Montreal.
+
+2. **Descriptive summary**: Draw up a small summary table (type of establishment, total number, average fine).
+
+3. **Rare categories**: Determine if any of the categorical variables (`SOC_NOM_ARTCL_INFRC` and `Type_establishment`) have rare or almost unexploited categories. Should we group it together?
+:::
+
+Remember to generate your report, commit your changes and push to GitHub to keep track of your work! 🚀
+
+----------------------------------------------------------------------------------
+
+# 📈 Categorical data visualization
+
+## ✨ Explanations
+
+To visually represent categorical variables, we often use:
+
+- **Bar charts** (`geom_bar()` or `geom_col()`),
+
+- **Pie chart** (less recommended, except for very simple use),
+
+- **Mosaic plots** if you want to compare several crossed categories.
+
+## 🚀 Demonstration
+
+```{r }
+library(ggplot2)
+
+# Example: Number of offenses by type of establishment
+condemnationlist %>%
+  ggplot(aes(x = establishment_type)) +
+  geom_bar(fill = "steelblue") +
+  theme(axis.text.x = element_text(angle = 45, hjust = 1)) + # allows you to rotate the label names on the x axis
+  labs(
+    title = "Offences by type of establishment in Montreal",
+    x = "Type of establishment",
+    y = "Number of offenses"
+  )
+```
+
+> **Idea**: Apply a `coord_flip()` if the names are too long!
+
+Let us question **the very nature of the offenses**. Knowing the dominant categories and their distribution across different types of establishments will help formulate a clear message for the general public.
+
+::: callout-tip
+#### Exercise
+
+1. **Top 5**: Focus on the 5 most frequent categories of `SOC_NOM_ARTCL_INFRC` (via sorting or `fct_lump()`).
+2. **Bar chart**: make a bar chart according to `SOC_NOM_ARTCL_INFRC` and the establishment type `Type_establishment`.
+3. **Good visualization practices**: Add a title, colors, modify the theme or the orientation of the axis for a clearer rendering.
+:::
+
+::: {.callout-important title="🧑‍💼 - Note from Alexandre"}
+*“This graphic should speak to the reader in the blink of an eye. Make sure to indicate that 5 categories already cover X% of offenses; This is a strong message for the introduction to your article. »*
+:::
+
+The **amount of fines** is a concrete indicator that often attracts the attention of the public and the media. Comparing these amounts between Montreal and the rest of Quebec, and between types of establishments, will support your conclusion.
+
+::: callout-tip
+#### Exercise
+
+1. **Boxplots**: Represent (with boxplots) the distribution of the amount of the fine within each `Type_establishment`.
+2. **Comparison**: Compare Montreal versus outside Montreal (two boxplots side by side, by type of establishment). What do you notice?
+3. **Handling missing data**: What do you do if `Amende` is missing in a subset? Explore some trails.
+:::
+
+::: {.callout-important title="🧑‍💼 - Note from Alexandre"}
+*“Remember to cite one or two significant figures in your text: for example, the median fines in Montreal versus outside Montreal. It will make your conclusions more impactful. »*
+:::
+
+----------------------------------------------------------------------------------
+
+# 🚀 5. Go further: map fines (optional)
+
+To close the investigation, **Alexandre** got his hands on a piece of R code written by a colleague from the City; This script automatically geocodes zip codes and provides a latitude/longitude for each establishment. You will use it to draw up **a map of the distribution of fines**.
+
+```{r geocode-helper, echo=TRUE}
+# ────────────────────────────── ──────────────────────────────
+# Utility function: from postal code (e.g. "H2X 3X2") to lon/lat
+# Uses tidygeocoder + Nominatim geocoding API (OpenStreetMap)
+geocode_pc <- function(df, pc_col = "postal_code") {
+  df %>%
+     #1) Clean up postal codes: remove spaces, capital letters
+    mutate(
+      postal_tmp = str_remove_all(.data[[pc_col]], "\\s"),
+      postal_tmp = str_to_upper(postal_tmp),
+      #2) Re-insert the space if the string is precisely 6 characters long
+      postal_std = if_else(
+        nchar(postal_tmp) == 6,
+        str_replace(postal_tmp, "^(.{3})(.{3})$", "\\1 \\2"),
+        postal_tmp
+      )
+    ) %>%
+    tidygeocoder::geocode(address = postal_std, method = "osm",
+                          lat = latitude, long = longitude,
+                          timeout = 5) %>%
+    select(-postal_tmp, -postal_std) # we clean the temporary columns
+}
+
+# ────────────────────────────── ──────────────────────────────
+```
+
+> **Note**: You must install the `tidygeocoder` package to use this function. You can do this with `install.packages("tidygeocoder")`.
+
+::: callout-tip
+#### Exercise – Fines map
+
+1. **Geocoding**: Apply `geocode_pc()` to your dataset, making sure to keep `Fine`.\
+2. **Aggregation**: calculate the **total amount of fines per geocoded point** (e.g. per restaurant or by coordinates rounded to the 4th decimal).\
+3. **Static map**: use `ggplot2 + geom_point()` on a simple background (`coord_sf()`); the size or color of the point may reflect the cumulative amount.\
+:::
+
+```{r solution-map, message=FALSE, warning=FALSE, echo=FALSE, eval=FALSE}
+library(viridis)
+#1. Geocoding (sample for demo; remove slice_head() in final render)
+offenses_geo <- convictionlist %>%
+  mutate(Amende = as.numeric(Amende_clean)) %>%
+  select(postal_code, fine = Fine) %>%
+  filter(!is.na(postal_code), !is.na(fine)) %>%
+  slice_head(n = 500) %>%
+  geocode_pc(pc_col = "postal_code") %>%
+  mutate(pc_round = paste0(round(latitude, 4), "_", round(longitude, 4)))
+
+#2. Aggregation by geocoded point
+pts_card <- geo_offenses %>%
+  group_by(pc_round) %>%
+  summarize(lat = mean(latitude), lon = mean(longitude),
+            total_fine = sum(fine, na.rm = TRUE), .groups = "drop")
+
+#3. Static Map
+ggplot(map_pts, aes(lon, lat)) +
+  geom_point(aes(size = total_fine, color = total_fine), alpha = 0.7) +
+  scale_size_continuous(labels = scales::dollar_format()) +
+  scale_color_viridis_c(labels = scales::dollar_format()) +
+  coord_sf(crs = 4326) +
+  labs(title = "Cumulative amount of fines per establishment (sample)",
+       size = "Cumul $", color = "Cumul $") +
+  theme_void()
+```
+
+::: callout-important
+**Advice from Alexandre**: *“A visual is worth a thousand words. Choose a **zoom in on the city center** where the density of fines is highest, and cite a key figure (e.g. $180,000 in fines within a 2km radius). Your article will gain in impact. »*
+:::
+
+----------------------------------------------------------------------------------
+
+# 🔚 Conclusion of the adventure
+
+This third adventure allowed you to **move from the role of analyst to that of data journalist**: you cleaned a real set of food inspections, quantified major infractions, compared establishment profiles and visualized the geography of fines.
+
+You now have:
+
+- a **set of numerical results** (top 5 offenses, average amounts, proportion of Montreal vs. outside of Montreal, etc.);
+- **impactful graphs** (bar charts, boxplots, map) to support your arguments;
+- **qualitative observations** provided by Alexandre, which direct the story towards the issues of hygiene and citizen transparency.
+
+## ✍️ Next step: write your article
+
+1. **Structure your Quarto article**: catchy hat ➜ context ➜ methodology ➜ key results ➜ recommendations.\
+2. **Integrate at least two visuals** among those produced (a category graph and the fines map).\
+3. **Cite two narrative figures** (e.g. “5 categories cover 62% of offenses”, “180,000\$ fines within a 2km radius”) to captivate the reader.\
+4. **Add a summary quote from Alexander** to humanize your conclusion.
+
+> **Expected deliverable**: a standalone HTML file exported from your `.qmd`, committed to your GitHub repository before the deadline.
+
+Happy writing! Let the data speak and put yourself in the shoes of the journalist who informs, nuances and proposes. 🚀
+
+> 🎯 **Congratulations**! You have practiced the concepts of categorical variables, descriptive statistics, and visualization for real categorical data. Continue like this, the next module awaits you.

--- a/en/module_03/plan_apprentissage.qmd
+++ b/en/module_03/plan_apprentissage.qmd
@@ -1,0 +1,297 @@
+---
+title: "Module 3 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# Module objectives
+
+At the end of this module, you should be able to
+
+- Handle character strings with `stringr`.
+- Recognize patterns with regular expressions.
+- Use regular expressions to select, manipulate and modify character strings.
+- Calculate and interpret descriptive statistics for categorical variables (frequency tables, proportions, including by groups, cross-tabulation).
+- Produce and interpret visualizations of categorical variables with `ggplot2` (bar, stacked bar, standardized stacked bar, grouped stacked bar, mosaic, pie and waffle plots).
+
+# Initial readings
+
+## 📘 Readings to do before the adventure
+
+In this module, we will explore **categorical** variables and **visualization adapted** to this type of data. Two readings are suggested to prepare you:
+
+- [**R for Data Science – Strings**](https://r4ds.hadley.nz/strings.html){target="_blank"}\
+    This chapter introduces you to the manipulation of character strings with the `stringr` package.\
+    \> 📝 **Note**: Although this chapter is most widely used in module 4, some useful functions like `str_detect()` or `str_to_lower()` can already help you clean or prepare categorical variables.
+
+- [**Introduction to Modern Statistics – Chapter 6: Explore categorical data**](https://openintro-ims.netlify.app/explore-categorical){target="_blank"}\
+    This chapter of **IMS** introduces statistical concepts associated with categorical data. We talk in particular about frequency tables, proportions and ways to visually represent this type of variable.
+
+Take the time to browse these two resources. They will be useful for you to understand how to process **qualitative data**, both from a **statistical** and **practical** point of view.
+
+# Adventure
+
+[Adventure 3](aventure.qmd)
+
+# Challenge
+
+At the end of this module, **you will take on the role of data journalist** for *Le Courrier Gourmand*.\
+Your mission:
+
+1. **Explore and clean** the `listecondemnation` game (food offenses in Quebec).\
+2. **Extract key facts** (top offenses, fine amounts, Montreal/non-Montreal comparison).\
+3. **Illustrate your analyses** with at least **two visuals** (a category graph + the fines map).\
+4. **Write a Quarto article (HTML)** clear and eye-catching: hat ➜ context ➜ methodology ➜ results ➜ recommendations.\
+5. **Cite two narrative figures** and **integrate a short quote from Alexander** to humanize the conclusion.
+
+> **To be submitted**: the `.qmd` file and the generated HTML, delivered via your GitHub repository before the deadline.
+
+## 📝 Evaluation grid
+
+Your article will be evaluated according to the following criteria. Make sure you follow the template provided and the instructions given.
+
+| Criterion | Excellent (3) | Satisfactory (2) | To improve (1) | Comment |
+|----------------------|-------------|-------------|-------------|-------------|
+| **📰 Introductory hat** | Punchy hook, clear angle, well-chosen key figures | Present but not very engaging or unclear | Absent or very vague |  |
+| **📊 Context & presentation of data** | Well identified source, relevance explained, limitations mentioned | Partial context or summary explanation | Source absent or not justified |  |
+| **🧪 Methodology (section without code)** | Well summarized, clear and logical approach | Present but confusing or too technical | Absent or very unclear |  |
+| **📈 Key result #1 (graph + interpretation)** | Clear visual, good interpretation, obvious analytical contribution | Visual or in-depth commentary | Visual or analysis absent |  |
+| **📊 Key result #2 (graph + interpretation)** | Relevant visual, well-formulated insight | Correct visual but weak analysis | Result little exploited or missing |  |
+| **📉 Key result #3 (graph + interpretation)** | Original or complementary result, well explained | Present but underdeveloped | Lacking or superficial |  |
+| **🧠 Discussion (section 4)** | Critical reflection, putting results into perspective | Partial or descriptive discussion | Discussion absent or without added value |  |
+| **✅ Conclusion & recommendations** | Clear, useful, well-formulated action messages | Messages present but not convincing | Unclear or off-topic |  |
+| **🗣️ Narrative figures + quote from Alexandre** | Two well-chosen figures + well-integrated quote | One of the elements present only | None or poorly integrated |  |
+| **📂 Render quality (Quarto + GitHub repository)** | `.qmd` functional, readable HTML, clean and complete repository | Some technical problems or disorganized filing | Unable to execute or rendered partial/absent |  |
+
+----------------------------------------------------------------------------------
+
+🧮 **Total out of 30 points**: `XX / 30`
+
+> ✍️ *Don’t forget to reread the checklist at the end of the template before publishing your article.*
+
+# Consolidation exercises
+
+```{r warning=FALSE, message=FALSE}
+# Load the necessary libraries
+library(tidyverse)
+library(stringr)
+```
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 1 – Identify categorical variables
+
+Here is a small dataset:
+
+```{r}
+data <- tibble::tibble(
+  sex = c("Man", "Woman", "Woman", "Man", "Man"),
+  age = c(25, 32, 29, 40, 23),
+  region = c("East", "West", "East", "North", "South")
+)
+```
+
+> Among the three variables above, which are categorical?
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+The `sex` and `region` variables are **categorical**. `age` is **numeric**.
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 2 – Frequency table
+
+Creates a frequency table for the variable `sex`.
+
+::: {.callout-tip collapse="true"}
+### 💡 Track
+
+Uses `count()` from the `dplyr` package.
+:::
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+data %>% count(sex)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 3 – Proportions
+
+Calculates the percentages for each category of the `region` variable.
+
+::: {.callout-tip collapse="true"}
+### 💡 Track
+
+Adds a column with `mutate(n / sum(n))`.
+:::
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+data %>% count(region) %>% mutate(percent = n / sum(n) * 100)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 4 – Barplot of a categorical variable
+
+Make a barplot representing the `region` variable.
+
+::: {.callout-tip collapse="true"}
+### 💡 Track
+
+Use `geom_bar()` with `aes(x = region)`.
+:::
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+ggplot(data, aes(x = region)) + geom_bar()
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 5 – Comparison of two categorical variables
+
+Adds a color by `sex` in the previous graph.
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+ggplot(data, aes(x = region, fill = sex)) + geom_bar(position = "dodge")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 6 – Cleaning a categorical variable
+
+Here is an inconsistent categorical variable:
+
+```{r}
+answers <- c("Yes", "yes", "No", "no", "YES", "NO")
+```
+
+Cleans up this variable so that all responses are lowercase **and without duplicates**.
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+unique(str_to_lower(answers))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 7 – Crosstab
+
+Here is another dataset:
+
+```{r}
+data2 <- tibble(
+  smoker = c("Yes", "No", "No", "Yes", "Yes", "No", "No"),
+  sport = c("Yes", "Yes", "No", "No", "Yes", "No", "No")
+)
+```
+
+Creates a crosstab (contingency) between the two variables.
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+data2 %>% count(smoker, sport) %>% pivot_wider(names_from = sport, values_from = n, values_fill = 0)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### ❓ Exercise 8 – To go further: Mosaic plot
+
+Uses the `ggplot2` package (or `ggmosaic` if available) to visually represent the relationship between `smoking` and `sport`.
+
+::: {.callout-note collapse="true"}
+### ✅ Solution with ggplot2
+
+```{r}
+# By grouping into grouped bars for an approximation
+ggplot(data2, aes(x = smoker, fill = sport)) +
+  geom_bar(position = "fill") +
+  ylab("Proportion")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 📦 Problems
+
+### 🐧 Exercise 9 – Palmer Penguins
+
+We use the `penguins` dataset from the `palmerpenguins` package.
+
+- Categorical variable: `species`, `island`, `sex`
+- Numeric variable: `flipper_length_mm`, `body_mass_g`
+
+Questions: 1. Create a frequency table for `species` 2. Visualize the distribution of species by island 3. Compare the sexes for each species
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+library(palmerpenguins)
+
+penguins %>% count(species)
+
+ggplot(penguins, aes(x = island, fill = species)) + geom_bar(position = "dodge")
+
+ggplot(penguins, aes(x = species, fill = sex)) + geom_bar(position = "fill")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+### 🚌 Exercise 10 – Titanic Data
+
+Use `titanic::titanic_train`
+
+Categorical variables: `Sex`, `Embarked`, `Survived`
+
+Questions: 1. Cross-tabulation between `Sex` and `Survived` 2. Proportion of survival by port of embarkation (`Embarked`) 3. Cross-tabulation `Sex` × `Embarked` × `Survived`
+
+::: {.callout-note collapse="true"}
+### ✅ Solution
+
+```{r}
+library(titanic)
+titanic_train <- titanic::titanic_train
+
+titanic_train %>% count(Sex, Survived)
+
+titanic_train %>% count(Embarked, Survived) %>%
+  group_by(Embarked) %>% mutate(p = n / sum(n))
+
+ggplot(titanic_train, aes(x = Embarked, fill = factor(Survived))) +
+  geom_bar(position = "fill") +
+  facet_wrap(~Sex)
+```
+:::

--- a/en/module_04/aventure.qmd
+++ b/en/module_04/aventure.qmd
@@ -1,0 +1,440 @@
+---
+title: "Adventure 4 - Clean up to insure better"
+subtitle: "STT-1100 Introduction to Data Science"
+author: 
+  - institute: “Laval University”
+format: 
+  html:
+    toc: true
+    toc-title: "Adventure plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../css/base_css.css]
+editor:visual
+editor_options: 
+  chunk_output_type: console
+---
+
+# 🧠 Scenario
+
+You have just started an internship as a **junior data engineer** at a large **insurance company**. You work with Alex, an experienced business analyst, who has entrusted you with an important mission.
+
+Alex has provided you with a database taken from an old archive system. This database contains key information on customers, insurance policies and claims. Unfortunately, the database is **riddled with errors**: duplicates, missing values, inconsistencies, format errors, typos, etc.
+
+Your role will be to ensure **data quality** to allow Alex to carry out a reliable analysis.
+
+# 🎯 Adventure objectives
+
+- Import a raw database (`Dataset_pratique.csv`).
+- Identify different types of common errors.
+- Clean and transform data with `dplyr`, `forcats` and `stringr`.
+- Clearly document **all modifications made** to the database.
+
+# ✅ How to succeed in this adventure?
+
+At the end of this adventure, you will:
+
+1. Provide a **clean database** (`own_data.csv`).
+2. Maintain a **structured R list** called `cleanup_log` in your script.
+
+> 💡 Remember to **document each step of your cleaning**. Your rigor is your best ally!
+
+# 🗃️ Typology of errors and structure of the list
+
+Here is a reference table for the types of errors you may encounter:
+
+| Code | Error type | Description | Example |
+|------------------|------------------|------------------|------------------|
+| VM | Missing values ​​| Essential fields not filled in | Lines with no value for `age` or `annual_income` |
+| DF | Duplicates | Identical or very similar lines | Two lines with the same `client_id` |
+| IF | Format inconsistencies | Data of the same type but different formats | `birth_date` in mixed formats (`1980-01-01`, `01/01/1980`) |
+| VA | Outliers | Obviously extreme or unrealistic values ​​| `annual_income = $99,999,999` |
+| FT | Typos | Typographical errors affecting consistency | Province listed as "Quebec", "quebec", "Quebec" |
+| CR | Recoding or grouping | Categories similar to merge | "unemployed", "inactive", "unemployed" |
+| TY | Ill-defined types | Wrong variable type for data | `annual_income` saved as text |
+| LG | Logical errors | Incorrect temporal or conditional relationships | Customer born in 2022 but contract signed in 2020 |
+| IC | Inter-variable inconsistencies | Inconsistent data between two columns | `province = "Quebec"` but `postal_code` starts with "H" |
+| UK | Redundant or unnecessary data | Duplicate or irrelevant columns | Two columns containing the same information |
+| TR | Truncations or bad merge | Truncated or incorrectly merged text strings | Surnames hyphenated like "Du" |
+| EC | Encoding issues | Incorrectly encoded special characters | "Ã©" instead of "é" |
+
+This typology makes it possible to rigorously structure the detection and documentation of errors in the R cleaning log (list `journal_nettoyage`).
+
+In your script, you will construct the `journal_nettoyage` list structured by category:
+
+```{r}
+cleaning_log <- list(
+  VM = list(
+    list(
+      id = c(12, 27),
+      variables = "age",
+      problem = "Missing values",
+      action = "Replaced by median",
+      justification = "To maintain consistency"
+    )
+  ),
+  DF = list(
+    list(
+      id = c(45, 46),
+      variables = "client_id",
+      problem = "Complete duplicates",
+      action = "Delete",
+      justification = "Useless for analysis"
+    )
+  )
+)
+cleaning_log
+```
+
+Each category (`VM`, `DF`, etc.) contains a **list of fixes**, where each fix is a `list()` with:
+
+- `id`: affected line(s) or position(s)
+
+- `variables`: the variables concerned
+
+- `problem`: nature of the problem
+
+- `action`: action performed
+
+- `justification`: why this action was chosen
+
+> 🔁 This structure will help you **report your changes** in a clean and professional manner.
+
+# 🧪 GitHub and rendering
+
+As for previous adventures:
+
+- **Clone** the module 4 GitHub repository from the course organization. You can use the course cheat sheet if you have a memory lapse.
+- Work in RStudio and **make commits regularly** to document your progress.
+- Your deposit must contain:
+    - the `.qmd` script for your adventure, that is to say a document where you do your tests and build your `journal_nettoyage` list;
+    - the `journal_nettoyage` list in a `.Rdata` object;
+    - the cleaned database in `.csv` format.
+
+Good luck, and may your data be clean! 🧽📊
+
+# 📥 Data import
+
+Before cleaning a database, you need to know how to import it correctly. For this mission, Alex has sent you the `Dataset_pratique.csv` file. He recommends that you:
+
+- load the data into R with the `read_csv()` function of the `readr` package,
+- examine the first lines to spot obvious inconsistencies,
+- and immediately convert the column names to lowercase with `janitor::clean_names()` to facilitate future manipulations.
+
+``` r
+library(readr)
+library(janitor)
+
+# Data import
+base <- read_csv("practical_dataset.csv")
+
+# Cleaning up column names
+base <- base %>% clean_names()
+
+# Data overview
+head(base)
+glimpse(base)
+```
+
+> 💬 **Alex**: “This base is a real headache! I need you to make it usable quickly. You should start by spotting what's wrong with names, formats or values. »
+
+----------------------------------------------------------------------------------
+
+# 🔍 Initial exploration of potential issues
+
+## Format of variables
+
+Now that you have imported the database, it is time to do a first exploration to identify potential errors. Here are some key steps to follow:
+
+``` r
+# Base dimensions
+nrow(base)
+ncol(base)
+
+# Variables available
+names(base)
+
+# type of variables
+glimpse(base)
+```
+
+> 💬 **Alex**: “You'll see, some types of variables don't make any sense... Keep track of everything you find weird so that we can decide together what to do with it. »
+
+One of the most useful functions here is `glimpse()` (from the `dplyr` package). It displays a preview of the first values ​​of each variable **as well as their type**: for example `chr` for a character string, `dbl` for a decimal number (double), `int` for an integer, or even `lgl` for a boolean.
+
+Here is a reminder of the main data types in R:
+
+- `character` (`chr`): text
+
+- `numeric` / `double` (`dbl`): real numbers
+
+- `integer` (`int`): integers
+
+- `logical` (`lgl`): booleans (`TRUE`, `FALSE`)
+
+- `factor`: categorical variable with defined levels
+
+- `Date`: date in standard R format
+
+To transform a variable, you can use the following functions:
+
+```         
+as.character(base$column)
+as.numeric(base$column)
+as.integer(base$column)
+as.logical(base$column)
+as.factor(base$column)
+```
+
+Remember to always check the result of the transformation with `glimpse()` or `summary()`.
+
+> 💬 Alex: “When we look at the types of variables with glimpse(), we must keep in mind that there are standards in data science. In general, variables containing text should be of type `character` or `factor` if they take a limited number of values ​​(for example, a gender or province column). Variables containing numbers should normally be of type `dbl` (for decimals) or `int` (for integers), as appropriate.
+
+> A common pitfall is identifiers! Even if they appear to be numbers, like a `client_ID` or `contract_number` column, they are not quantities on which we are going to do calculations. These are unique labels. We should therefore convert them to character. This prevents an identifier like 0012 from being transformed into 12 by mistake, or from R thinking that we want to do an average with that… 😅
+
+> In short, check each type carefully. Ask yourself: is this variable text? Am I going to calculate on it? Are these categories? »
+
+## 🔁 Checking for duplicates
+
+One of the first reflexes to have in any cleaning operation: **check for duplicates**. It could be:
+
+- **complete** duplicates (identical lines on all columns),
+- **partial** duplicates (same identifier, but slightly different values elsewhere).
+
+💡 Start by detecting full duplicates with:
+
+``` r
+duplicated(base) %>% sum()
+```
+
+And to identify them:
+
+``` r
+base[duplicated(base), ]
+```
+
+You can then remove them:
+
+``` r
+base <- base %>% distinct()
+```
+
+If you want to spot duplicates on one or more key columns (e.g. `ID_Variable`), use:
+
+``` r
+basis %>% 
+  group_by(Variable_ID) %>% 
+  filter(n() > 1)
+```
+
+> 💬 **Alex**: “Two customers with the same number is fishy. Look what's happening. Blindly deleting is not always the right solution. Note carefully what you do in the `cleaning_journal`! »
+
+And of course, if you intervene, don't forget to indicate it in the `DF` section of your `cleaning_journal`.
+
+``` r
+cleaning_log$DF <- append(cleaning_log$DF, list(
+  list(
+    id = c(101, 102),
+    variables = "All columns",
+    problem = "Complete duplicates",
+    action = "Lines deleted",
+    justification = "Exact duplicates detected automatically"
+  )
+))
+```
+
+# 🧹 Cleaning factors with `forcats`
+
+We continue the exploration with a type of variable that is often neglected... but which can derail an entire analysis: **factors**.
+
+In R, factors are used to represent **categories**. For example, in the `VEHICLE_TYPE` column, each value corresponds to a vehicle type: `"car"`, `"truck"`, `"CAR"`, `"ANIMAL"`, etc.
+
+To see all the levels of a factor, you can use the `levels()` function:
+
+```{r, eval=FALSE}
+levels(base$VEHICLE_TYPE)
+```
+
+Of course, your variable must be of type `factor` for this function to work. If this is not the case, you can convert it with `as.factor()` (see previous section).
+
+The problem?\
+When looking at the levels of a factor, we often notice **disguised duplicates** ("car"` vs `"CAR"`), **aberrant levels** ("ANIMAL"`) or **very rare categories** that may not deserve their own level.
+
+## 🛠 Some useful tools (with `forcats`)
+
+To clean this up, here are some key functions of the `forcats` package:
+
+- `fct_count()`: to count levels and spot anomalies
+- `fct_recode()`: to rename levels (for example merge `"CAR"` and `"car"`)
+- `fct_collapse()`: to merge several levels into one
+- `fct_lump()`: to group rare levels into “Other”
+- `fct_relevel()` or `fct_infreq()`: to reorder the levels
+
+## 👀 Suggested steps
+
+Take the time to:
+
+1. **List factor type variables** with `glimpse()` or `select(where(is.factor))`.
+2. **Explore levels** with `fct_count()`.
+3. **Identify inconsistencies**, such as:
+    - same values with different case (`"CAR"` vs `"car"`)
+    - typos (`"Commute"` vs `"Com.mute"`)
+    - aberrant levels ("ANIMAL"` in `VEHICLE_TYPE`)
+
+> 💬 **Alex**: “Be careful of these strange values. If a value makes no sense in context (e.g. `"ANIMAL"` in a column about vehicle types), don't guess. Set it to `NA`. We prefer missing data to bad information. »
+
+## ✏️ Example to adapt
+
+``` r
+# Harmonize lowercase/uppercase
+base$VEHICLE_TYPE <- base$VEHICLE_TYPE %>% 
+  str_to_title() %>% # "car" -> "Car", "TRUCK" -> "Truck"
+  as_factor()
+
+# Replace outliers with NA
+base$VEHICLE_TYPE <- na_if(base$VEHICLE_TYPE, "ANIMAL")
+
+# Or by changing the levels directly:
+base$VEHICLE_USE <- fct_collapse(
+  base$VEHICLE_USE,
+  Pleasure = c("Pleasure", "Pleasure"),
+  Commute = c("Commute", "Comm.mute"))
+```
+
+Don't forget to document these modifications in your `cleaning_journal` list! For example, for the `VEHICLE_USE` variable above, you could add:
+
+```{r}
+cleaning_log$RC <- append(cleaning_log$RC, list(
+  list(
+    id = c(101, 203, 317), # Adapt with the correct lines concerned
+    variables = "VEHICLE_USE",
+    problem = "Merging similar levels (capital letters/mistakes)",
+    action = "Grouping of 'Pleasure' and 'pleasure', 'Commute' and 'Com.mute'",
+    justification = "Improving consistency and reducing duplication"
+  )
+))
+```
+
+⚠️ *These are just examples. It's up to you to explore the database and choose what is consistent.*
+
+# 🧼 Cleaning recipe — Deep dive
+
+Well done! You've already fixed the variable types and cleaned up the most visible factors. Now, we push the cleaning further, by crossing **statistics**, **logical relationships** and **aberrant behaviors**. Here is your **advanced cleaning recipe**.
+
+## 📊 Step 1 – Descriptive statistics on numerical variables
+
+Just as we checked the factor levels, we must check if certain **numerical values are aberrant**.
+
+Take each numeric variable and summarize it with `summary()` or a boxplot to identify extremes.
+
+💡 **Example: `COMMUTE_DISTANCE`**
+
+``` r
+summary(base$COMMUTE_DISTANCE)
+ggplot(base, aes(x = SWITCH_DISTANCE)) +
+  geom_histogram(bins = 50, fill = "blue", alpha = 0.7) +
+  labs(title = "Distribution of commuting distance",
+       x = "Distance (km)", y = "Frequency")
+```
+
+Ask yourself: - Is a distance of 3000 km to work plausible? - Are some values ​​missing or negative?
+
+If you intervene, don't forget to **justify in `journal_nettoyage`**, using the code `VA` (outliers) or `VM` (missing values).
+
+## 📉 Step 2 – Inconsistent combinations of two factors
+
+**Logical relationships** can exist between two categorical variables. For example, quarter (`QUARTER`) and season (`SEASON`) should be consistent.
+
+💡 **Example: `QUARTER` and `SEASON`**
+
+``` r
+table(base$QUARTER, base$SEASON)
+```
+
+> 💬 **Alex**: “If you see `QUARTER = 1` with `SEASON = "Summer"`, you should wince... This kind of inconsistency is worth noting, even if you don't know what to correct. »
+
+You can also visualize with a crossbar chart:
+
+``` r
+ggplot(base, aes(x = QUARTER, fill = SEASON)) +
+  geom_bar(position = "fill")
+```
+
+If you correct, use the code `CI` (inter-variable inconsistencies).
+
+## 👶 Step 3 – Grouped Statistics: Factor + Numeric
+
+Another check: are some **numeric values inconsistent for certain groups**?
+
+💡 **Example: `AGE` according to `GENERATION`**
+
+``` r
+basis %>% 
+  group_by(GENERATION) %>% 
+  summarize(min = min(AGE, na.rm = TRUE),
+            max = max(AGE, na.rm = TRUE),
+            mean = mean(AGE, na.rm = TRUE))
+
+ggplot(base, aes(x = AGE, fill = GENERATION)) +
+  geom_histogram(position = "identity", alpha = 0.6, bins = 40)
+```
+
+- Does a baby belong to generation X?
+- Is a 122 year old person well classified?
+
+If there is recoding or grouping to be done, use the code `RC`.
+
+## 🧠 Step 4 – Logical links between two numeric variables
+
+Here, we verify that the numerical relationships **make sense**.
+
+💡 **Example: `AGE` vs `YEARS_LICENSED`**
+
+``` r
+ggplot(base, aes(x = AGE, y = YEARS_LICENSED)) +
+  geom_point(alpha = 0.3) 
+```
+
+- Are there points above certain lines? What line are we talking about here?
+- Can you have more years of license than age?
+
+> 💬 **Alex**: “You don’t have to correct it here. On the other hand, **if you notice something strange**, take two minutes to write it down in the `cleaning_journal`. Just to show that you saw it, thought about it, and made a decision. That’s being rigorous. »
+
+Use the code `LG` here for a **logical error**.
+
+## 🧪 Step 5 – Advanced checks (optional but professional!)
+
+Here are a few other things to keep an eye out for:
+
+- **Redundant variables**: two columns that say the same thing (`CITY_NAME` and `MUNICIPALITY`)
+- **Useless columns**: internal identifiers, empty columns or with only one category (`EC` or `RU`)
+- **Text format issues**: accents, special characters (`stringr::str_detect`)
+- **Hastily merged columns**: strings like `"Smith, John"` in one cell instead of two (`TR`)
+- **Mixed date format**: we have left this aside since the beginning of this course, but know that it is coming, we will have a special module on dates.
+
+🧾 *Throughout your cleaning, document your decisions in the `cleaning_journal` list. The goal is not to correct everything, but to show that you have been able to spot problems, reflect, and intervene when necessary.*
+
+# 🎉 Mission accomplished!
+
+Well done for making it to the end of this adventure! 🧽\
+You have now acquired a solid methodology for cleaning data in a rigorous and professional manner. You have:
+
+- identified and corrected format, type and consistency errors;
+- used the `dplyr`, `stringr`, `forcats` and `ggplot2` tools to explore the data from every angle;
+- documented each intervention in a clear and transparent structure with the `cleaning_journal` list.
+
+💾 **Before finishing**, don't forget to **push to GitHub** the following three items:
+
+1. 📄 The `.qmd` script of your adventure (where you carried out your tests, analyzes and cleaning)\
+2. 📦 The `journal_nettoyage` list saved in a `.Rdata` object\
+3. 📊 The cleaned database in `.csv` format
+
+To save your list in a `.Rdata` file, simply use this code at the end of your script:
+
+``` r
+save(cleaning_journal, file = "cleaning_journal.Rdata")
+```
+
+> 💬 **Alex**: “You have just done what few people do well: clean data cleanly, keeping track of your decisions. This is what distinguishes a true professional from someone who is tinkering. Hat ! »

--- a/en/module_04/plan_apprentissage.qmd
+++ b/en/module_04/plan_apprentissage.qmd
@@ -1,0 +1,204 @@
+---
+title: "Module 4 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# Module objectives
+
+At the end of this module, you should be able to
+
+- Import data from different formats (`txt`, `csv`, `excel`, `json`).
+- Clean and recode data to ensure its quality.
+- Use the `forcats` and `stringr` libraries to manipulate factors and character strings.
+- Create and use lists.
+
+# Initial readings
+
+## 📘 Readings to do before the adventure
+
+In this module, we will explore the basic concepts of data import and data cleansing. Here is some initial reading to prepare you:
+
+- [**R for Data Science – Data import**](https://r4ds.hadley.nz/data-import.html){target="_blank"}\
+    This chapter introduces you to importing data with the `readr` package.\
+
+- [**R for Data Science – Data tidying**](https://r4ds.hadley.nz/data-tidy.html){target="_blank"}\
+    This chapter introduces you to data manipulation with the `dplyr` package.\
+
+- [**R for Data Science – Factors**](https://r4ds.hadley.nz/factors.html){target="_blank"}\
+    This chapter introduces you to **factors** in R, which are categorical variables.\
+    \> 📝 **Note**: Although this chapter is more widely used in module 4, some useful functions like `factor()` or `fct_reorder()` can already help you manipulate categorical variables (module 3).
+
+- [**R for Data Science – Import spreadsheets**](https://r4ds.hadley.nz/spreadsheets.html){target="_blank"}\
+    This chapter introduces you to importing data from Excel files.\
+
+- [**R for Data Science – Lists**](https://r4ds.hadley.nz/rectangling.html#lists){target="_blank"}\
+    This section introduces you to the concept of lists in programming.\
+
+# Adventure
+
+[Adventure 4](aventure.qmd)
+
+# Challenge
+
+At the end of the adventure, you should be able to have placed the following elements in your Github folder:
+
+- the `.qmd` script for your adventure, that is to say a document where you do your tests and build your cleaning_journal list;
+
+- the `journal_nettoyage` list in a `.Rdata` object;
+
+- the cleaned database in `.csv.` format
+
+# 📝 Consolidation exercises
+
+### Exercise 1 – Controlled reading of a CSV (Data import, § readr)
+
+Import `policies.csv` as:
+
+- forcing `policy_id` to **character**;
+
+- leaving `premium_amount` as **double**
+
+then display the structure of the object.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(readr)
+
+policies <- read_csv(
+  "policies.csv",
+  col_types = cols(
+    policy_id = col_character(),
+    premium_amount = col_double()
+  )
+)
+glimpse(policies)
+```
+:::
+
+### Exercise 2 – Cleaning up missing values (Data import, ex. 4)
+
+The file contains the string `"missing"` to indicate an absence in `vehicle_type`.\
+Re-import the file by converting it to `NA`.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+policies <- read_csv("policies.csv", na = "missing")
+```
+:::
+
+### Exercise 3 – Long ↔ wide passage (Data tidy, § pivot)
+
+The `q1_claims:q4_claims` columns represent the number of claims per quarter.
+
+1. Put them in *long* (`quarter`, `claims`).
+
+2. Then return to *wide*.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(tidyr)
+library(dplyr)
+
+pol_long <- policies %>% 
+  pivot_longer(
+    cols = q1_claims:q4_claims,
+    names_to = "quarter",
+    values_to = "claims"
+  )
+
+pol_wide <- pol_long %>% 
+  pivot_wider(names_from = quarter, values_from = claims)
+```
+:::
+
+### Exercise 5 – Read a specific Excel sheet (Import spreadsheets, ex. 3)
+
+The workbook `quotes_2024.xlsx` has a sheet “Q3” where the labels start on the 2nd line.\
+Import it and check the types.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(readxl)
+
+q3 <- read_excel(
+  "resources/quotes_2024.xlsx",
+  sheet = "Q3",
+  skip = 1 # we skip the first line
+)
+glimpse(q3)
+```
+:::
+
+### Exercise 6 – Parse numbers with locale (Data import, ex. 5)
+
+The `euro_premium` column contains “1,234.56” (decimal point, space 000).\
+Parse it correctly as a `double`.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(readr)
+
+parse_number("1234.56", locale = locale(decimal_mark = ",", grouping_mark = " "))
+```
+:::
+
+### Exercise 7 – Rectangling a JSON list (Lists, ex. 1-2)
+
+You have a list `lst <- jsonlite::read_json("coverage.json")`.
+
+1. Get `lst$collision$limit`.
+
+2. Transform `lst` into a rectangular tibble.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(jsonlite)
+library(tidyr)
+library(dplyr)
+
+lst <- read_json("coverage.json")
+limit <- lst$collision$limit
+
+tbl <- tibble(row = lst) %>% 
+  unnest_wider(row)
+```
+:::
+
+### Exercise 8 – Express pipeline (Summary)
+
+In three lines:
+
+1. import `policies.csv`;
+
+2. clean names (`janitor::clean_names`);
+
+3. return the **5** largest `claim_amount` by `vehicle_type`.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply\`\`\`r
+
+library(readr); library(dplyr); library(janitor)
+
+read_csv("policies.csv") %\>% clean_names() %\>% slice_max(claim_amount, n = 5, by = vehicle_type) \`\`\`
+:::

--- a/en/module_05/aventure.qmd
+++ b/en/module_05/aventure.qmd
@@ -1,0 +1,343 @@
+---
+title: "Adventure 5 - Explore and understand relationships between data"
+subtitle: "STT-1100 Introduction to Data Science"
+author: 
+  - institute: “Laval University”
+format: 
+  html:
+    toc: true
+    toc-title: "Adventure plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../css/base_css.css]
+editor:visual
+editor_options: 
+  chunk_output_type: console
+---
+
+# 🕹️ Scenario — Adventure 5
+
+You put on the shoes (and secure badge!) of an **airport operations statistician** newly recruited by the **Port Authority Data Lab (PADL)**, the analytics team of the **Port Authority of New York & New Jersey**.\
+Your mission: to help **JFK** airport (and, ultimately, **EWR** and **LGA**) to streamline departures and reduce **time lost on the ground**.
+
+- **Your teammate**: **Dr Sofia Martínez**, senior data scientist recognized for her impactful interactive visualizations. Sofia asks the right questions, validates your hypotheses and gives you access to internal resources.\
+- **The dataset**: **Alex Chen**, data engineer at PADL, has prepared a file **`flights_merged_2023.rds`** for you which brings together in a single exhaustive table the 2023 flights, the weather at departure time, plane information, the full names of the companies and the geolocation of the origin and destination airports.\
+- **Concrete context**: the Operations Board wants to know *when* and *why* delays explode, how the weather affects connections, and which companies should review their flight plans. Your deliverables (Quarto reports + visualizations) will guide budgetary decisions for summer 2026.
+
+> 📝 **Brief from Sofia**\
+> 1. Which time slots systematically display the highest delays?\
+> 2. How much of the delays is attributable to the weather compared to other factors?\
+> 3. Are older planes (\> 20 years old) more prone to cancellations?
+>
+> It's up to you!
+
+# 🎯 Adventure objectives
+
+- Use `lubridate` functions to manipulate and enrich temporal data.
+- Carry out an exploratory data analysis (EDA) to better understand their structure and identify interesting patterns.
+- Visualize relationships between variables using `ggplot2`.
+- Interpret simple statistical results, such as correlation.
+- Answer concrete questions related to real issues (delays, weather, aircraft fleet).
+
+# ✅ How to succeed in this adventure?
+
+Here are some tips from Sofia to succeed in your mission:
+
+- Start by **exploring the data** and understanding its structure. You can use `glimpse()`, `summary()`, or even an interactive table.
+- Uses `lubridate` functions to create useful time columns (day, month, hour, etc.).
+- For each question, **structure your analysis**:
+    - explain what you are looking to test;
+    - show your code;
+    - interprets the result.
+- Favor clear and well-annotated visualizations. Don’t forget to add titles, axes, etc.
+- Comment your code if necessary. Imagine working as a team with Sofia!
+
+And above all… **ask yourself questions**! The important thing is to develop your analytical reasoning.
+
+# 🧪 GitHub and rendering
+
+As for previous adventures:
+
+- **Clone** the module 5 GitHub repository from the course organization. You can use the course cheat sheet if you have a memory lapse.
+
+- Work in RStudio and **make commits regularly** to document your progress.
+
+- Your deposit must contain:
+
+- a well-structured **`rapport.qmd`** file containing:
+
+    - your R code;
+
+    - commented visualizations;
+
+    - clear interpretations for each analysis requested;
+
+    - `callout` boxes (type `.tip`, `.warning`, etc.) to highlight your conclusions;
+
+    - a **`rapport.html`** file generated from `.qmd` (you can use the "Render" button in RStudio);
+
+    - all files necessary for reproducing your work (e.g.: preparation script, `flights_merged_2023.rds` dataset, etc.).
+
+- The depot must remain **clean and well organized**:
+
+    - do not keep unnecessary files;
+    - avoid file names like `Untitled1.Rmd` or `copy report final.qmd` 😊 ;
+    - comment on your commits with clear and descriptive messages.
+
+> 📌 **Reminder**: The `.qmd` is your main document. It should allow any member of the team (or Sofia!) to understand what you did and why.
+
+# 📅 Understand and manipulate dates with `lubridate`
+
+Before diving into delay and performance analyses, Sofia wants to make sure that you are familiar with managing **dates and times** in R. The `lubridate` package is an essential tool for this.
+
+## 🧰 Essential Features
+
+Here are the main functions you will use:
+
+| Function | Utility |
+|------------------------------------------------|------------------------|
+| `make_date()` | Creates a variable of type `Date` from `year`, `month`, `day` |
+| `make_datetime()` | Creates a complete time object (`POSIXct`) with `hour` |
+| `wday()` | Give the day of the week |
+| `month()` | Give the month |
+| `hour()` | Extract the time |
+| `ymd()` | Transform a string like `"2023-01-01"` into `Date` |
+| `floor_date()` | Truncates a date to day, week, month, etc. |
+
+``` r
+# Example of creating date and datetime
+<flights- flights %>%
+  mutate(
+    date = make_date(year, month, day),
+    datetime = make_datetime(year, month, day, hour)
+  )
+```
+
+## ❓ Exercise 1 — What is the structure of the date?
+
+::: callout-question
+**Sofia asks you**: *Create a `date` variable from the `year`, `month` and `day` columns, then use `class()` to check the type of this new variable.*
+:::
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+You can use:
+
+``` r
+flights <- flights %>% mutate(date = make_date(year, month, day))
+class(flights$date)
+```
+
+The expected type is `"Date"`. You can now manipulate this variable with all time functions!
+:::
+
+## ❓ Exercise 2 — Day of the week
+
+::: callout-question
+**Sofia asks you**: *Add a `day_week` column which gives the day of the week (Monday, Tuesday, etc.) for each flight. Shows first 7 results.*
+:::
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+Here is one way to do it:
+
+``` r
+<flights- flights %>%
+  mutate(weekday = wday(date, label = TRUE, abbr = FALSE))
+
+head(flights$weekday, 7)
+```
+
+This uses `label=TRUE` to get the full name (not a number).
+:::
+
+## ❓ Exercise 3 — Time slot
+
+::: callout-question
+**Sofia asks you**: *Create a variable `moment_journee` which classifies flights as "night", "morning", "afternoon" or "evening" depending on the scheduled departure time.*
+:::
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+Here is a suggestion:
+
+``` r
+<flights- flights %>%
+  mutate(moment_day = case_when(
+    hour < 6 ~ "night",
+    hour < 12 ~ "morning",
+    hour < 18 ~ "afternoon",
+    TRUE ~ “evening”
+  ))
+```
+
+You can then explore the delays according to these time slots.
+:::
+
+## ❓ Exercise 4 — Is it a weekend?
+
+::: callout-question
+**Sofia asks you**: *Add a logical variable `weekend` which is `TRUE` if the flight takes place on a Saturday or a Sunday.*
+:::
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+Use:
+
+``` r
+<flights- flights %>%
+  mutate(weekend = weekday %in% c("Saturday", "Sunday"))
+```
+
+Don't forget that `day_week` is a factor variable with labels.
+:::
+
+# 🔍 Explore and understand relationships between data
+
+Now that you are comfortable with dates and times, Sofia wants to introduce you to a key step in any data science project: **exploratory data analysis**, often abbreviated to **EDA** (*Exploratory Data Analysis*).
+
+The objective is simple: **understand the structure of the data, spot patterns, anomalies, or interesting correlations between variables**.
+
+## 🛠️ Tools at your disposal
+
+You can rely on:
+
+- **Descriptive statistics**: `summary()`, `mean()`, `median()`, `sd()`, `n_distinct()`, etc.
+- **Visualization** with `ggplot2`:
+    - `geom_histogram()` or `geom_density()` for distributions
+    - `geom_point()` to visualize relationships between two numeric variables
+    - `geom_boxplot()` to compare a numeric variable according to a categorical variable
+    - `geom_bar()` for categorical variables
+- **Crosstabs** with `count()`, `group_by()` + `summarise()`
+- **Correlations** with `cor()` or `ggcorrplot::ggcorrplot()` for a graphical matrix
+
+Sofia now invites you to examine **concrete questions** related to flight performance and delays. You will have to analyze the data to come up with a clear interpretation.
+
+----------------------------------------------------------------------------------
+
+## ❓ Analysis 1 — What time should you avoid leaving?
+
+::: callout-note
+**Background**: The JFK Operations Manager has observed that delays seem to be more frequent at certain times of the day. He wants to validate if there are **critical slots** to avoid for departures.
+:::
+
+::: callout-question
+**Sofia asks you**: *Do an analysis to identify the times of day when departure delays (`dep_delay`) are highest on average. Visualize this relationship with a clear graph.*
+:::
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+You can group flights by time and calculate the average delays:
+
+``` r
+flights %>%
+  group_by(hour) %>%
+  summarise(mean_delay = mean(dep_delay, na.rm = TRUE)) %>%
+  ggplot(aes(x = hour, y = average_delay)) +
+  geom_col(fill = "steelblue") +
+  labs(title = "Average delay at departure according to time",
+       x = "Planned departure time",
+       y = "Average delay (minutes)")
+```
+
+Warning: don’t get trapped by late hours with few flights!
+:::
+
+## ❓ Analysis 2 — Is the weather really the culprit?
+
+::: callout-note
+**Context**: Some managers systematically blame the weather for delays. Sofia suggests that you test this **hypothesis** using the weather data attached to the flights.
+:::
+
+::: callout-question
+**Sofia asks you**: *Choose one or two weather variables (e.g. `wind_gust`, `visib`, `precip`) and examine their relationship with delays (`dep_delay`).*
+:::
+
+Before diving into the visualizations, a quick detour through a key concept: **correlation**.
+
+### 📈 What is correlation?
+
+Correlation measures the **strength and direction of a linear relationship** between two numerical variables. Its value is between:
+
+- **-1**: perfectly **negative** correlation (when one increases, the other decreases),
+- **0**: **no linear relationship** detected,
+- **+1**: perfectly **positive** correlation (the two variables increase together).
+
+💡 For example, if wind gusts (`wind_gust`) increase and delays also increase, we should observe a **positive correlation**.
+
+----------------------------------------------------------------------------------
+
+### 🧪 Step 1 — Calculate the correlation
+
+``` r
+flights %>%
+  select(dep_delay, wind_gust, visib, precip) %>%
+  cor(use = "complete.obs") %>%
+  round(2)
+```
+
+This table gives you a quick overview of the strength of the relationship between delays (`dep_delay`) and certain weather variables.
+
+### 🧪 Step 2 — Visualize a relationship
+
+A scatter chart allows you to **see** the trend between two variables. For example, you can test:
+
+``` r
+ggplot(flights, aes(x = wind_gust, y = dep_delay)) +
+  geom_point(alpha = 0.2) +
+  geom_smooth(method = "lm", color = "red") +
+  labs(title = "Relationship between wind gusts and departure delay",
+       x = "Wind gusts (mph)",
+       y = "Departure delay (min)")
+```
+
+The scatter plot shows you the overall trend, and the red line corresponds to a **linear regression** (i.e. the "best" line which represents the linear link between the two variables) which estimates this relationship.
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+You can also test with other variables like `visib` (visibility) or `precip` (precipitation), and observe if delays are higher when the weather is bad.
+
+Caution:
+
+- Correlations do not prove a **causal** link!
+
+- Some weather delays are **indirect** (e.g. from another airport).
+:::
+
+## ❓ Analysis 3 — Are old planes less reliable?
+
+::: callout-note
+**Context**: The maintenance team is wondering: are older planes more often late or canceled? Information on the year of manufacture is available in `plane_year`.
+:::
+
+::: callout-question
+**Sofia asks you**: *Analyze the relationship between the age of the plane and delays or cancellations (`is.na(dep_time)`).*
+:::
+
+::: {.callout-tip collapse="true"}
+**Reply from Sofia**\
+You can create an `airplane_age` variable:
+
+``` r
+<flights- flights %>%
+  mutate(plane_age = 2023 - plane_year)
+```
+
+Then compare:
+
+``` r
+flights %>%
+  filter(!is.na(plane_age)) %>%
+  group_by(airplane_age) %>%
+  summarise(p_cancellation = mean(is.na(dep_time)),
+            delay_mean = mean(dep_delay, na.rm = TRUE)) %>%
+  ggplot(aes(x = aircraft_age, y = average_delay)) +
+  geom_line() +
+  labs(title = "Average delay according to the age of the plane",
+       x = "Age of aircraft (years)", y = "Average delay (minutes)")
+```
+
+You can also do a `geom_bar()` for the cancellation rate by age group.
+:::

--- a/en/module_05/exercices.qmd
+++ b/en/module_05/exercices.qmd
@@ -1,0 +1,199 @@
+---
+title: "Module 5 - Exercises"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# Module objectives
+
+At the end of this module, you should be able to
+
+# Initial readings
+
+## 📘 Readings to do before the adventure
+
+In this module, we will explore the basic concepts of data import and data cleansing. Here is some initial reading to prepare you:
+
+- [**R for Data Science – Data import**](https://r4ds.hadley.nz/data-import.html){target="_blank"}\
+    This chapter introduces you to importing data with the `readr` package.\
+
+- [**R for Data Science – Data tidying**](https://r4ds.hadley.nz/data-tidy.html){target="_blank"}\
+    This chapter introduces you to data manipulation with the `dplyr` package.\
+
+- [**R for Data Science – Factors**](https://r4ds.hadley.nz/factors.html){target="_blank"}\
+    This chapter introduces you to **factors** in R, which are categorical variables.\
+    \> 📝 **Note**: Although this chapter is more widely used in module 4, some useful functions like `factor()` or `fct_reorder()` can already help you manipulate categorical variables (module 3).
+
+- [**R for Data Science – Import spreadsheets**](https://r4ds.hadley.nz/spreadsheets.html){target="_blank"}\
+    This chapter introduces you to importing data from Excel files.\
+
+- [**R for Data Science – Lists**](https://r4ds.hadley.nz/rectangling.html#lists){target="_blank"}\
+    This section introduces you to the concept of lists in programming.\
+
+# Adventure
+
+[Adventure 4](https://sitescours.monportail.ulaval.ca/contenu/sitescours/036/03609/202509/site177541/modules1395096/module1747262/ page4742827/bloccontenu5043393/Aventure%204.html?identifiant=afa8069a82b693eba79bcfb3092d453ef69c140a){target="_blank"}
+
+# Challenge
+
+At the end of the adventure, you should be able to have placed the following elements in your Github folder:
+
+- the `.qmd` script for your adventure, that is to say a document where you do your tests and build your cleaning_journal list;
+
+- the `journal_nettoyage` list in a `.Rdata` object;
+
+- the cleaned database in `.csv.` format
+
+# 📝 Consolidation exercises
+
+### Exercise 1 – Controlled reading of a CSV (Data import, § readr)
+
+Import `policies.csv` as:
+
+- forcing `policy_id` to **character**;
+
+- leaving `premium_amount` as **double**
+
+then display the structure of the object.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(readr)
+
+policies <- read_csv(
+  "policies.csv",
+  col_types = cols(
+    policy_id = col_character(),
+    premium_amount = col_double()
+  )
+)
+glimpse(policies)
+```
+:::
+
+### Exercise 2 – Cleaning up missing values (Data import, ex. 4)
+
+The file contains the string `"missing"` to indicate an absence in `vehicle_type`.\
+Re-import the file by converting it to `NA`.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+policies <- read_csv("policies.csv", na = "missing")
+```
+:::
+
+### Exercise 3 – Long ↔ wide passage (Data tidy, § pivot)
+
+The `q1_claims:q4_claims` columns represent the number of claims per quarter.
+
+1. Put them in *long* (`quarter`, `claims`).
+
+2. Then return to *wide*.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(tidyr)
+library(dplyr)
+
+pol_long <- policies %>% 
+  pivot_longer(
+    cols = q1_claims:q4_claims,
+    names_to = "quarter",
+    values_to = "claims"
+  )
+
+pol_wide <- pol_long %>% 
+  pivot_wider(names_from = quarter, values_from = claims)
+```
+:::
+
+### Exercise 5 – Read a specific Excel sheet (Import spreadsheets, ex. 3)
+
+The workbook `quotes_2024.xlsx` has a sheet “Q3” where the labels start on the 2nd line.\
+Import it and check the types.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(readxl)
+
+q3 <- read_excel(
+  "resources/quotes_2024.xlsx",
+  sheet = "Q3",
+  skip = 1 # we skip the first line
+)
+glimpse(q3)
+```
+:::
+
+### Exercise 6 – Parse numbers with locale (Data import, ex. 5)
+
+The `euro_premium` column contains “1,234.56” (decimal point, space 000).\
+Parse it correctly as a `double`.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(readr)
+
+parse_number("1234.56", locale = locale(decimal_mark = ",", grouping_mark = " "))
+```
+:::
+
+### Exercise 7 – Rectangling a JSON list (Lists, ex. 1-2)
+
+You have a list `lst <- jsonlite::read_json("coverage.json")`.
+
+1. Get `lst$collision$limit`.
+
+2. Transform `lst` into a rectangular tibble.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply
+
+``` r
+library(jsonlite)
+library(tidyr)
+library(dplyr)
+
+lst <- read_json("coverage.json")
+limit <- lst$collision$limit
+
+tbl <- tibble(row = lst) %>% 
+  unnest_wider(row)
+```
+:::
+
+### Exercise 8 – Express pipeline (Summary)
+
+In three lines:
+
+1. import `policies.csv`;
+
+2. clean names (`janitor::clean_names`);
+
+3. return the **5** largest `claim_amount` by `vehicle_type`.
+
+::: {.callout-note collapse="true"}
+### ✅ Reply\`\`\`r
+
+library(readr); library(dplyr); library(janitor)
+
+read_csv("policies.csv") %\>% clean_names() %\>% slice_max(claim_amount, n = 5, by = vehicle_type) \`\`\`
+:::

--- a/en/module_05/plan_apprentissage.qmd
+++ b/en/module_05/plan_apprentissage.qmd
@@ -1,0 +1,269 @@
+---
+title: "Module 5 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Module objectives
+
+At the end of this module, you should be able to:
+
+- Manage and analyze temporal variables using `lubridate`.
+- Study the relationship between two variables using graphs and descriptive statistics, particularly using the correlation coefficient.
+- Calculate and interpret the correlation between two numerical variables.
+- Write an exploratory data analysis (EDA) report highlighting trends and patterns in the data.
+
+# 📚 Readings
+
+In this module, we will explore the basic concepts of exploratory data analysis (EDA) and date and time manipulation. Here is some initial reading to prepare you:
+
+- [**R for Data Science – EDA**](https://r4ds.hadley.nz/EDA.html){target="_blank"}\
+    This chapter introduces you to exploratory data analysis (EDA) with the `ggplot2` package.\
+
+- [**R for Data Science – Dates and Times**](https://r4ds.hadley.nz/datetimes.html){target="_blank"}\
+    This chapter introduces you to the manipulation of dates and times with the `lubridate` package.\
+
+You can also review the following chapter:
+
+- [**R for Data Science – Tidy Data**](https://r4ds.hadley.nz/tidy-data.html){target="_blank"}\
+    This chapter reminds you of the principles of the “tidy” data structure and how to apply them with `tidyr`.\
+
+In the free **IMS**:
+
+- [**Introduction to modern statistics – Applications: Explore**](https://openintro-ims.netlify.app/explore-applications){target="_blank"}\
+    This chapter introduces you to best practices for exploratory data modeling.
+
+# Adventure
+
+[Adventure 5](aventure.qmd)
+
+# 🎯 Challenge — Analyze delays to support decisions
+
+In this challenge, you must submit a **professional report** intended for your supervisor, **Dr Sofia Martínez**, in order to answer the three major strategic questions posed in the adventure. Your role is to provide clear analysis, supported by relevant visualizations and rigorous interpretations.
+
+## 📌 What you should do
+
+From the merged data provided (`flights_merged_2023.rds`), you must:
+
+1. **Explore temporal variables** (`date`, `day_week`, `moment_day`, etc.) and prepare them if necessary.
+2. **Answer Sofia's three big questions**:
+    - What time slots should you avoid to reduce delays?
+    - To what extent is the weather responsible for the delays?
+    - Are older planes more often delayed or canceled?
+3. For each question:
+    - carry out a relevant **exploratory analysis**;
+    - produce **at least one clear visualization**;
+    - write a **concise interpretation** of your results.
+
+## ✏️ What the report should contain
+
+Your **`rapport.qmd`** file must include:
+
+- A short **introduction** which recalls the context (work at JFK, role with Sofia, etc.).
+- A section for each **question** of the brief.
+- Your **analyses** (reproducible R code, tables or graphs, comments).
+- Your **interpretations** to highlight the key findings.
+- A **short conclusion** which summarizes the answers given to managers.
+
+## 🚀 Upload and rendering
+
+- Publish the report to your GitHub repository in the course organization.
+- Make sure that the `.html` file is properly generated and readable.
+- Do a final proofread to check **clarity, structure and presentation**.
+
+> 🧠 Tip: Put yourself in the shoes of a professional analyst — this report could be presented to the airport executive committee!
+
+----------------------------------------------------------------------------------
+
+## 🧾 Evaluation grid (10 points)
+
+| Criterion | Description | Points |
+|-------------------|--------------------------------|-------------------|
+| **Time exploration (`lubridate`)** | Creation of `date`, `day_week`, `moment_day` variables; good use of `lubridate`. | 2 |
+| **Time slot analysis** | Relevance of the analysis, quality of visualization and interpretation. | 2 |
+| **Weather analysis** | Judicious choice of weather variables, test of relationship with delays, correct interpretation. | 2 |
+| **Analysis of old planes** | Construction of `age_avion`, correct analysis of delays or cancellations, relevant interpretation. | 2 |
+| **Structure and presentation of the report** | Clear, well-structured, visually readable report; well-annotated visualizations; commented code. | 2 |
+
+> 💡 **Bonus** possible (max +1) for an original additional analysis (e.g.: analysis by company or distance).
+
+# 🧠 Consolidation exercises
+
+These exercises will allow you to consolidate the skills of module 5: exploration, correlation, visualization, bivariate analysis. All datasets used are integrated into R.
+
+## 🚗 1. Dataset: mtcars
+
+How strong is the linear relationship between fuel consumption (mpg) and weight (wt) of cars?
+
+::: {.callout-tip collapse="true"}
+``` r
+cor(mtcars$mpg, mtcars$wt)
+# ≈ -0.87 → strong negative correlation: heavier cars consume more.
+```
+:::
+
+## 🌡️ 2. Dataset: airquality
+
+Create a graph showing the relationship between temperature (Temp) and ozone level (Ozone), with a trend line.
+
+::: {.callout-tip collapse="true"}
+``` r
+ggplot(airquality, aes(x = Temp, y = Ozone)) +
+  geom_point() +
+  geom_smooth(method = "lm")
+```
+:::
+
+## 📆 3. Dataset: airquality
+
+Create a date variable from Month and Day (assuming the year 1973), then add a column indicating the day of the week.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(lubridate)
+
+airquality <- airquality %>%
+  mutate(date = make_date(1973, Month, Day),
+         weekday = wday(date, label = TRUE))
+```
+:::
+
+## 🦷 4. Dataset: ToothGrowth
+
+Compare the length of teeth (len) according to the type of supplement (supp) using a boxplot.
+
+::: {.callout-tip collapse="true"}
+``` r
+ggplot(ToothGrowth, aes(x = supp, y = len)) +
+  geom_boxplot()
+```
+:::
+
+## 💊 5. Dataset: ToothGrowth
+
+Calculate the average tooth length for each combination of supplement (supp) and dose (dose).
+
+::: {.callout-tip collapse="true"}
+``` r
+ToothGrowth %>%
+  group_by(supp, dose) %>%
+  summarise(mean = mean(len), .groups = "drop")
+```
+:::
+
+## 🌸 6. Dataset: iris
+
+Calculate the correlation matrix between the numerical variables.
+
+::: {.callout-tip collapse="true"}
+``` r
+iris %>%
+  select(where(is.numeric)) %>%
+  cor() %>%
+  round(2)
+```
+:::
+
+## 🐣 7. Dataset: ChickWeight
+
+Plot the change in weight over time for a single chick (e.g. Chick 1).
+
+::: {.callout-tip collapse="true"}
+``` r
+ggplot(filter(ChickWeight, Chick == 1), aes(x = Time, y = weight)) +
+  geom_line()
+```
+:::
+
+## 🐥 8. Dataset: ChickWeight
+
+What is the average weight of the chicks at the end of the experiment (Time = 21) for each type of diet (Diet)?
+
+::: {.callout-tip collapse="true"}
+``` r
+ChickWeight %>%
+  filter(Time == 21) %>%
+  group_by(Diet) %>%
+  summarise(mean = mean(weight))
+```
+:::
+
+## 🌿 9. Dataset: iris
+
+Visualize the distribution of Petal.Length using a histogram with superimposed density curve.
+
+::: {.callout-tip collapse="true"}
+``` r
+ggplot(iris, aes(x = Petal.Length)) +
+  geom_histogram(aes(y = ..density..), bins = 20, fill = "lightblue") +
+  geom_density(color = "blue")
+```
+:::
+
+## ⚙️ 10. Dataset: mtcars
+
+How many cars are there for each combination of number of cylinders (cyl) and transmission type (am)?
+
+::: {.callout-tip collapse="true"}
+``` r
+mtcars %>%
+  count(cyl, am)
+```
+:::
+
+## 🔍 Problem 1 — Weather and ozone EDA (dataset: airquality)
+
+1. Visualize the relationship between wind speed (`Wind`) and ozone level (`Ozone`).
+2. Calculate their correlation.
+3. Add a logical variable `hot_day` which is `TRUE` if the temperature is above 85°F.
+4. Compare the ozone levels according to `hot_day` with a boxplot.
+
+::: {.callout-tip collapse="true"}
+``` r
+ggplot(airquality, aes(x = Wind, y = Ozone)) +
+  geom_point() +
+  geom_smooth(method = "lm")
+
+cor(airquality$Wind, airquality$Ozone, use = "complete.obs")
+
+airquality <- airquality %>%
+  mutate(hot_day = Temp > 85)
+
+ggplot(airquality, aes(x = hot_day, y = Ozone)) +
+  geom_boxplot()
+```
+:::
+
+## 🔍 Problem 2 — Floral EDA (dataset: iris)
+
+1. Does the `Sepal.Length` variable allow us to distinguish between species (`Species`)?
+2. Display a boxplot of `Sepal.Length` by species.
+3. Calculate the mean and standard deviation of `Sepal.Length` per species.
+4. Calculate the correlation between `Sepal.Length` and `Petal.Length`.
+5. Visualize their relationship with a scatter plot and trend line.
+
+::: {.callout-tip collapse="true"}
+``` r
+ggplot(iris, aes(x = Species, y = Sepal.Length)) +
+  geom_boxplot()
+
+iris %>%
+  group_by(Species) %>%
+  summarise(mean = mean(Sepal.Length),
+            deviation = sd(Sepal.Length))
+
+cor(iris$Sepal.Length, iris$Petal.Length)
+
+ggplot(iris, aes(x = Petal.Length, y = Sepal.Length)) +
+  geom_point() +
+  geom_smooth(method = "lm")
+```
+:::

--- a/en/module_06/aventure.qmd
+++ b/en/module_06/aventure.qmd
@@ -1,0 +1,146 @@
+---
+title: "Adventure 6 — Collaboration and reproducibility in GitHub"
+subtitle: "STT-1100 • Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: "Adventure plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../css/base_css.css]
+editor:visual
+editor_options:
+  chunk_output_type: console
+---
+
+# ✈️ Put in context
+
+You are a team of data scientists working for JFK Airport. Your mandate is to produce a **collaborative and reproducible analysis** aimed at identifying the sources of flight delays, particularly in relation to the weather.
+
+Each member of your team will need to actively contribute to this analysis, which will be produced using **Quarto** and hosted on **GitHub**.
+
+# 🔧 Part 1 — Collaboration with GitHub: roles, branches, conflicts
+
+## 👥 Team training and roles in the data lifecycle
+
+Work in **teams of 3 to 4 people**. Each member embodies an essential role in the **lifecycle of data and a data science project**. These roles will be maintained for the following steps.
+
+| Role | Technical functions | Link to data lifecycle | To do in this activity |
+|-----------------|-----------------|-----------------------|-----------------|
+| **Responsible for the deposit** | Creates and structures the GitHub repository, manages branches and merges | Ensures **versioning**, traceability and documentation | Creates repository, manages *pull requests*, merges branches, resolves conflicts |
+| **Data Analyst** | Prepare data transformation and merging code | Manages the **preparation and transformation** stage | Add a `chunk` to merge `flights`, `airlines`, `weather` into the `.qmd` |
+| **Reproducibility Manager** | Organizes the `.qmd`, ensures compilation and clarity | Guarantor of **reproducibility and documentation** | Sets up sections of `.qmd`, cleans up rendering, checks final HTML rendering |
+| **Viewer** (optional) | Produces graphics, harmonizes style | Plays a key role in **communication and dissemination** | Adds an illustrative ggplot2 `chunk` and adapts titles/captions |
+
+> 🔁 **Recommended role turn** in the adventure to raise awareness at all stages of the cycle.
+
+## 🛠 Steps to follow
+
+Here is a suggested sequence for team members to work **one after the other**, while others observe and learn:
+
+1. **Repository maintainer**: Clone the starting repository provided by the teacher, create the RStudio project, initialize the branches for each member and make a first commit with an updated `README.md`.
+
+2. **Responsible for reproducibility**: Create your branch, organize the `.qmd`, add a basic structure with titles and subtitles. Add a comment in the YAML or section to create a small upcoming conflict.
+
+3. **Data analyst**: Create your branch, add the first lines of code to import the data and merge the tables. Add a `chunk` named `merge_data`.
+
+4. **Visualizer** (if present): Add a first draft of a simple visualization (`geom_bar()` or `geom_point()`) with clear `labs()`. Push your changes to your branch and open a *pull request*.
+
+5. **Repository manager**: Merge the *pull requests* one by one. When a conflict arises (e.g. in the intro or YAML), manage it directly with other members who observe and take notes on the process.
+
+6. Once all the branches have been merged, compile the `.qmd` into HTML and validate the rendering with the team.
+
+## ✅ Part 1 Objectives
+
+- [ ] One branch per role with at least one commit
+- [ ] All branches merged with conflict management
+- [ ] The `.qmd` compiles to HTML
+- [ ] The team presentation is complete
+- [ ] Everyone thought about their place in the **data lifecycle**
+
+# 🔍 Part 2 — Reproducible analysis with merged data
+
+## 👥 Tasks by role
+
+Each member of the team continues their previously defined role. Here are the expected actions for each, in the same order as Part 1:
+
+### 🗂 Responsible for the repository — Start of analysis
+
+- Creates a specific branch for collaborative analysis.
+- Reviews the organization of the repository and ensures that the necessary files are present.
+- Ensures that all chunks have consistent names, options (`echo`, `message`, etc.).
+- Check that each member has pushed its branch well.
+- Starts the coordination of the analysis step.
+
+### 🧪 Data Analyst
+
+- Creates a new section in `.qmd` titled *Collaborative Analysis*.
+- Check that the necessary libraries (`tidyverse`, `nycflights2`) are loaded in a `setup` chunk.
+- Prepare the following mergers:
+    - `flights` + `airlines` to add the name of the carriers.
+    - `flights` + `weather` to integrate weather conditions.
+- Filter on JFK airport only.
+- Clean data as needed (NA, duplicates, etc.).
+- Add useful statistical summaries (average delays, etc.).
+
+### 🧱 Responsible for reproducibility
+
+- Check that the necessary libraries (`tidyverse`, `nycflights2`) are loaded in a `setup` chunk.
+
+- Ensures that all chunks have consistent names, options (`echo`, `message`, etc.).
+
+- Checks that the document compiles properly.
+
+- Add **a sentence in the main text** using **inline code** (eg: `r nrow(flights)`), to show an example of reproducibility embedded in the text. The sentence must contain at least 3 different inline codes, for example: \> Example: "The dataset contains `r nrow(flights)` flights recorded in 2023."
+
+- Ensure that everything is reproducible in the report.
+
+### 📊 Visualizer (if present)
+
+- Creates at least two relevant charts from the merged table:
+    - A `geom_col()` showing the average delay per carrier.
+    - A `geom_point()` or `geom_smooth()` exploring the relationship between weather and delays.
+- Customizes the titles, axes, and readability of the graph.
+- Ensures that the graphs are clearly interpretable and aligned with the questions asked.
+
+### 🗂 Responsible for repository — End of analysis
+
+- Revises everyone's final contributions.
+- Merge clean branches into `main`.
+- Push the final version to GitHub.
+- Document the process in the `README.md` or in a “Production notes” section of the `.qmd`.
+
+# 🔁 Part 3 — Thinking and the data lifecycle
+
+## Logbook
+
+In this section, each team member writes a paragraph about:
+
+- His role in the project
+- Difficulties encountered with GitHub (and how they were resolved)
+- What he/she learned about collaboration and reproducibility
+
+The **project manager** must of course initialize the quarto logbook document and plan the sections for each member. Each member must then add their paragraph in their dedicated section.
+
+## Data lifecycle
+
+Add a section explaining how your project demonstrates the following steps:
+
+1. Collection
+2. Transformation
+3. Analysis
+4. Sharing
+5. Reuse and versioning
+
+# ✅ Final verification
+
+- Does the HTML report compile without errors?
+- Are there at least **2 visualizations**?
+- Have all members made **at least 2 commits**?
+- Is the report **clearly written and well structured**?
+
+----------------------------------------------------------------------------------
+
+Happy collaboration! 🎯

--- a/en/module_06/plan_apprentissage.qmd
+++ b/en/module_06/plan_apprentissage.qmd
@@ -1,0 +1,324 @@
+---
+title: "Module 6 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Module objectives
+
+At the end of this module, you should be able to:
+
+- Collaborate effectively on data science projects using `GitHub`.
+- Ensure the reproducibility of analyzes with `Quarto`.
+- Merge and manage multiple datasets.
+- Explain the data life cycle and the principles of `DataOps`.
+
+# 📚 Readings
+
+In this module, we'll explore the basic concepts of collaboration and reproducibility in GitHub, as well as using Quarto to create dynamic reports. Here is some initial reading to prepare you:
+
+- [GitHub Docs – Hello World](https://docs.github.com/en/get-started/quickstart/hello-world) First complete project: repository, branch, pull request then merge.
+- [GitHub Docs – About pull requests](https://docs.github.com/en/pull-requests) Learn everything about code review, comments and conflict resolution.
+- [Quarto Docs – Inline Code](https://quarto.org/docs/computations/inline-code.html) Insert R code directly into text to dynamically display values.
+- [What is DataOps? (DataKitchen)](https://datakitchen.io/what-is-dataops/) DataOps fundamentals: automation, quality, and collaboration. :contentReference[oaicite:0]{index="0"}\
+- [R for Data Science (2nd ed.) – Chapter 26: Joins](https://r4ds.hadley.nz/joins.html) Learn to combine data from different sources with `dplyr`.
+
+# Adventure
+
+[Adventure 6](aventure.qmd)
+
+# 🎯 Challenge — Cross-review of logbooks {.unnumbered}
+
+> Each team must **share their logbook** with another team and provide **constructive feedback**. This step simulates the peer review process and reinforces critical communication skills.
+
+## Steps to take
+
+1. **Assignment of pairs**: the teacher will publish a table listing for each team the logbook to be examined.
+
+2. **Sharing the document**:
+
+    - The repository manager adds the recipient team as a read/write *Collaborator* on GitHub.
+    - The URL of the HTML logbook is communicated.
+
+3. **Peer Review**:
+
+    - Each member of the review team opens an *Issue* in the review team repository and submits at least **one detailed comment** relating to:
+
+        1. **Clarity** of content (structure, titles, readability)
+        2. **Rigour** of the methodology (description of roles, reproducibility of the code)
+        3. **Relevance** of reflections (data life cycle, lessons learned)
+
+    - Comments must contain:
+
+        - A positive aspect statement (“what is successful”)
+        - A specific suggestion for improvement (“what could be clarified”)
+
+4. **Acknowledgement of receipt & review**:
+
+    - The receiving team responds to each *Issue* and, if deemed necessary, updates its logbook.
+
+## Deliverables
+
+| Team | Deliverable | Where to drop it off |
+|----------------|--------------------------------------|----------------|
+| **Reviewing team** | ≥ 3 *Issues* (one per member) containing full feedback | GitHub repository of the reviewed team |
+| **Revised team** | Updated logbook (if necessary modifications) + responses to *Issues* | Same GitHub repository |
+
+## Scale (20pts)
+
+| Criterion | Pts |
+|------------------------------------------------------------|----------|
+| Quality of comments (clarity, constructiveness, examples) | 10 |
+| Relevance of suggestions to reproducibility & collaboration | 5 |
+| Follow-up and responses from the revised team | 5 |
+
+----------------------------------------------------------------------------------
+
+> 💡 **Tip**: focus on actionable feedback (e.g. proposing a more descriptive title, adding an additional graphic, specifying a YAML parameter) rather than generic comments.
+
+# 🏋️ Consolidation exercises {.unnumbered}
+
+> **General objective – Master the different `dplyr` joins (`inner_join()`, `left_join()`, `right_join()`, `full_join()`, `semi_join()`, `anti_join()`) on various datasets.**
+
+----------------------------------------------------------------------------------
+
+## 1. Penguins & Islands
+
+*Datasets:* `palmerpenguins::penguins` and `palmerpenguins::penguins_raw` (package **palmerpenguins**). Add to each penguin the latitude (`lat`) and longitude (`long`) of its island by matching the variable `island`.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(palmerpenguins)
+
+islands <- penguins_raw |>
+  distinct(island, lat = latitude, long = longitude)
+
+penguins_loc <- penguins |>
+  left_join(islands, by = "island")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 2. Gapminder × ISO-3 Code
+
+*Datasets:* `gapminder::gapminder` (package **gapminder**) and `countrycode::codelist` (package **countrycode**). Retrieves the ISO‑3 code (`iso3c`) and FAO region for each country in `gapminder`. *Hint:* key = `country`.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(gapminder)
+library(countrycode)
+
+gap_iso <- gapminder |>
+  inner_join(
+    select(countrycode::codelist, country = country.name.en, iso3c, region_fao),
+    by = "country"
+  )
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 3. Star Wars – Species & Classifications
+
+*Dataset:* `dplyr::starwars` (package **dplyr**). Creates a `species_class` tibble listing some species and their **classification** (`mammal`, `reptilian`, etc.). Do a **`left_join()`** to add the `classification` column and calculate the average size (`height`) by classification.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+
+species_class <- tibble::tribble(
+  ~species, ~classification,
+  “Human”, “mammal”,
+  "Droid", "artificial",
+  "Gungan", "amphibian",
+  "Wookiee", "mammal"
+)
+
+starwars_cls <- starwars |>
+  left_join(species_class, by = "species") |>
+  group_by(classification) |>
+  summarise(mean_height = mean(height, na.rm = TRUE))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 4. Baseball – Canadian players
+
+*Datasets:* `Lahman::People`, `Lahman::Batting` (package **Lahman**).
+
+1. Obtain the list of players born in *Canada* (`birthCountry`).
+2. Calculate their batting average (`H/AB`) by merging People ↔ Batting on `playerID`.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(Lahman)
+
+can_players <- People |>
+  filter(birthCountry == "Canada") |>
+  select(playerID, nameFirst, nameLast)
+
+can_stats <- can_players |>
+  inner_join(select(Batting, playerID, H, AB), by = "playerID") |>
+  group_by(playerID, nameFirst, nameLast) |>
+  summarise(avg = sum(H, na.rm = TRUE) / sum(AB, na.rm = TRUE),
+            .groups = "drop")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 5. First names & First letter
+
+*Dataset:* `babynames::babynames` (package **babynames**). Creates an `alphabet` tibble with the first letter (`initial`) and its category (“A‑M”, “N‑Z”). Adds the category to `babynames`, then counts births by category in 2010.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(babynames)
+
+alphabet <- tibble::tibble(
+  initial = LETTERS,
+  group = if_else(initial <= "M", "A-M", "N-Z")
+)
+
+babynames_2010 <- babynames |>
+  filter(year == 2010) |>
+  mutate(initial = substr(name, 1, 1)) |>
+  inner_join(alphabet, by = "initial") |>
+  group_by(group) |>
+  summarize(total = sum(n))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 6. Canadian Weather – Stations & Observations
+
+*Datasets:* `weathercan::stations_meta()` and `weathercan::weather_dl()` (package **weathercan**). Download daily data for Québec‑Jean‑Lesage (station #7025250) for 2024 and attach it to station metadata to add `province` and `elevation`.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(weathercan)
+library(dplyr)
+
+meta <- stations_meta() |>
+  filter(station_id == 7025250) |>
+  select(station_id, province, elev = elevation)
+
+qc24 <- weather_dl(station_ids = 7025250,
+                   start="2024-01-01", end="2024-12-31",
+                   interval = "day")
+
+qc24_full <- qc24 |>
+  left_join(meta, by = "station_id")
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 7. Pizza Ratings
+
+*Datasets:* `fivethirtyeight::pizza` and `fivethirtyeight::pizza_places` (package **fivethirtyeight**). Associate each rating (`pizza`) with its restaurant (`pizza_places`) via `place_id` and find the average rating (`rating`) by **state**.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(fivethirtyeight)
+
+pizza_avg_state <- pizza |>
+  inner_join(pizza_places, by = "place_id") |>
+  group_by(state) |>
+  summarise(mean_rating = mean(rating, na.rm = TRUE))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 8. UN – Votes & Resolutions
+
+*Datasets:* `unvotes::un_votes`, `unvotes::un_roll_calls` (package **unvotes**). Links each vote (`un_votes`) to the description of the resolution (`un_roll_calls`) via `rcid`. Lists the five countries that voted "no" most often between 2000 and 2010.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(unvotes)
+
+votes_desc <- one_votes |>
+  inner_join(un_roll_calls, by = "rcid") |>
+  filter(year >= 2000, year <= 2010, vote == "no") |>
+  count(country, sort = TRUE) |>
+  slice_head(n = 5)
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 9. Movies & Oscars
+
+*Datasets:* `ggplot2movies::movies` (package **ggplot2movies**) and an `oscars` tibble listing some titles and the year of the Best Picture Oscar. Do a **`full_join()`** then locate the films present in only one of the two sets.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(ggplot2movies)
+
+oscars <- tibble::tribble(
+  ~title, ~oscar_year,
+  "The Hurt Locker", 2010,
+  "Argo", 2013,
+  "Parasite", 2020,
+  “Nomadland”, 2021
+)
+
+movies_oscar <- full_join(
+  select(movies, title, year, rating),
+  Oscars,
+  by = "title",
+  keep = TRUE
+)
+
+only_one_side <- movies_oscar |>
+  filter(is.na(year) | is.na(oscar_year))
+```
+:::
+
+----------------------------------------------------------------------------------
+
+## 10. **EDA mini-project** — Forest fires
+
+*Datasets:* `fires::fires` and `fires::fire_weather` (package **fires**).
+
+1. **Joins:** connects `fires` (incidents) and `fire_weather` (weather conditions) via `fid`.
+2. Calculate the average impact of temperature (`temp`) and wind (`wind`) on the burned surface area (`area`).
+3. Visualize `temp` × `area` with a scatterplot and a regression line.
+
+::: {.callout-tip collapse="true"}
+``` r
+library(dplyr)
+library(ggplot2)
+library(fires)
+
+fires_full <- fires |>
+  inner_join(fire_weather, by = "fid")
+
+summary_tbl <- fires_full |>
+  summarize(
+    mean_area = mean(area, na.rm = TRUE),
+    corr_temp = cor(temp, area, use = "complete.obs"),
+    corr_wind = cor(wind, area, use = "complete.obs")
+  )
+```
+:::

--- a/en/module_07/analyse_covid.qmd
+++ b/en/module_07/analyse_covid.qmd
@@ -1,0 +1,132 @@
+---
+title: "Initial analysis of COVID-19 cases"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+editor:visual
+---
+
+## Data context
+
+The dataset presented in this analysis simulates information collected during the year 2022 on cases of COVID-19 among elderly people living in three regions of Quebec: Montreal, Quebec and Outaouais. Each line represents an individual identified by their first name, last name, age, region, date of observation and the number of confirmed cases associated with them. The data also includes an observation date.
+
+```{r, echo=FALSE, message=FALSE, warning=FALSE}
+library(tidyverse)
+
+# Simulation of a problematic database
+set.seed(1234)
+covid_problematic <- data.frame(
+  first name = sample(c("Jean", "Marie", "Luc", "Chloé", "David"), 50, replace = TRUE),
+  name = sample(c("Dupont", "Lavoie", "Nguyen", "Morin", "Gagné"), 50, replace = TRUE),
+  age = sample(60:95, 50, replace = TRUE),
+  region = sample(c("Montreal", "Quebec", "Outaouais"), 50, replace = TRUE),
+  confirmed_cases = sample(60:150, 50, replace = TRUE),
+  date = sample(seq(as.Date('2022-01-01'), as.Date('2022-12-31'), by="day"), 50, replace = TRUE)
+)
+
+# Creating a variable with full name (privacy issue)
+covid_problematic <- covid_problematic %>%
+  mutate(person = paste(first name, last name, ",", age, "years"))
+
+# Data available for students
+available <- covid_problematic %>%
+  select(region, age, confirmed_cases, date)
+
+head(available)
+
+write_csv(available, “data_covid_module7.csv”)
+```
+
+## Visualization proposed by the research team
+
+```{r}
+case_by_region <- covid_problematic %>%
+  group_by(region) %>%
+  summarise(total_cases = sum(confirmed_cases), .groups = "drop")
+
+ggplot(cas_par_region, aes(x = region, y = total_cases, fill = region)) +
+  geom_bar(stat = "identity") +
+  scale_y_continuous(breaks = seq(0, max(cas_par_region$cas_totals), by = 10)) +
+  scale_fill_manual(values = c("Montreal" = "red", "Quebec" = "orange", "Outaouais" = "purple")) +
+  theme_minimal() +
+  theme(legend.position = "none")  
+```
+
+## Interpretation of results
+
+The graph above **clearly shows that the Montreal region is the most affected**, with a much higher number of cases than other regions. The data are **taken from our internal reports** collected during 2012. No adjustment by population was made, but this is not considered necessary.
+
+# Descriptive analysis
+
+## Table of notable cases
+
+In this section, we seek to identify the individuals who have generated the greatest number of confirmed cases.
+
+The following table shows the 5 people with the highest individual totals of confirmed cases according to our database:
+
+```{r}
+# Extraction of the 5 people with the highest number of confirmed cases
+covid_problematic %>%
+  arrange(desc(confirmed_cases)) %>%
+  select(person, region, confirmed_cases, date) %>%
+  head(5)
+```
+
+## Complementary exploratory analysis
+
+```{r}
+covid_problematic %>%
+  mutate(risk = if_else(age > 85 & confirmed_cases > 100, "High", "Moderate")) %>%
+  group_by(risk) %>%
+  summarize(
+    mean_age = mean(age),
+    mean_case = mean(confirmed_cases),
+    .groups = "drop"
+  )
+
+covid_problematic %>%
+  ggplot(aes(x = age, y = confirmed_cases)) +
+  geom_point(color = "darkred") +
+  geom_smooth(method = "lm", se = FALSE, linetype = "dashed") +
+  labs(title = "The older you are, the more you contract COVID")
+```
+
+## Immediate recommendations
+
+- The authorities should concentrate their efforts on **Montreal**, which seems to be in crisis.
+- People aged over 85 should be prioritized (see table).
+- The Quebec region seems little affected: resources could be redistributed.
+
+## Methodological note
+
+Data were pooled quickly without standardization by population. No margin of error, confidence interval or verification of sources has been provided. The data cover variable periods without harmonization.
+
+----------------------------------------------------------------------------------
+
+```{=html}
+<!-- 🧠 Issues intentionally included in this document:
+1. Axis truncated at 80 (artificially amplifies the differences)
+2. Garish and biased colors (red = danger, without justification)
+3. No caption or explanation of colors
+4. No explicit title or subtitle to the graphic
+5. Lack of source and date clearly indicated
+6. Inclusion of personally identifiable data (PII: full name, exact age)
+7. Non-anonymized data in the table
+8. No adjustment for regional population size
+9. Exaggerated and biased interpretations in the analysis section
+10. Recommendations not statistically justified
+11. No verification or indication of uncertainty (IC, margins of error)
+12. Data selection and non-uniform period (no consistent time window)
+13. Misuse of descriptive statistics
+14. Artificial correlation between age and cases (misleading presentation)
+15. Unjustified linear trend visualization (simplistic regression)
+16. Lack of reproducibility (no clear code to reproduce results)
+-->
+```
+
+**Educational note**: This document deliberately contains numerous visualization, ethical and analytical errors. It is used as a starting point for your critical mission.
+
+The `donnees_covid_module7.csv` file is the one you must use to produce a corrected version of the graph.

--- a/en/module_07/aventure.qmd
+++ b/en/module_07/aventure.qmd
@@ -1,0 +1,71 @@
+---
+title: "Adventure 7 — Visualization, ethics and data security"
+subtitle: "STT-1100 • Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: "Adventure plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../css/base_css.css]
+editor:visual
+editor_options:
+  chunk_output_type: console
+---
+
+# ✈️ Put in context
+
+You are an **invited expert** in a data science ethics committee. An organization submits a report to you containing visualization and statistics from a simulated COVID-19 dataset. Your role: assess the compliance of this report with good visual communication practices, ethics and the protection of sensitive data.
+
+# Adventure objectives
+
+- Develop your critical thinking in the face of misleading visualizations and biased interpretations.
+- Identify presentation biases, ethical errors and breaches of confidentiality (PII).
+- Apply good visualization practices (CRAP, axes, colors, legends).
+- Implement ethical principles in the processing and communication of data.
+
+## Instructions
+
+As a team, you must:
+
+1. **Read the provided report carefully** (`Initial Analysis of COVID-19 Cases.html`).
+2. **Identify all problems**: visual, statistical, ethical, methodological, etc.
+3. **Correct and improve the visualization** using the data file `donnees_covid_module7.csv`.
+4. **Write a critical report** including:
+    - Problems identified
+    - Ethical reasoning
+    - Recommendations
+5. **Provide one or more corrected visualizations** with explanations.
+6. **Add a short personal conclusion** (5 lines per person) on what you remember from this activity.
+
+## Work to be submitted
+
+A `.qmd` file on GitHub containing:
+
+- A “Critical Analysis” section
+- An “Improved visualization” section
+- A “Personal conclusion” section
+
+## Useful resources
+
+- CRAP rules: Contrast, Repetition, Alignment, Proximity
+- *How to Lie with Statistics* — Darrell Huff
+- Data anonymization rules (PII)
+- Ethical principles: transparency, reproducibility, non-harm
+- Good visualization practices with `ggplot2`
+- Concepts covered in module 7: security, bias, visualization, ethics
+
+## Starting file
+
+- `Initial analysis of COVID-19 cases.html` (provided on GitHub)
+- `donnees_covid_module7.csv` (cleaned data to use for the corrected version)
+
+## Success criteria
+
+- Ability to identify a large number of problems (technical, ethical, visual)
+- Ability to justify your corrections
+- Improved visualization quality (clarity, honesty, accessibility)
+- Quality of the critical report
+- Ability to adopt a reflective stance on ethics in data science

--- a/en/module_07/plan_apprentissage.qmd
+++ b/en/module_07/plan_apprentissage.qmd
@@ -1,0 +1,84 @@
+---
+title: "Module 7 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Module objectives
+
+At the end of this module, you should be able to:
+
+- Identify ethical issues in a visualization.
+- Correctly anonymize data.
+- Apply good visualization practices to represent data clearly and honestly.
+- Identify and avoid data presentation bias.
+- Understand the ethical and confidentiality issues related to data science.
+- Implement measures to protect and secure sensitive data.
+- Explain the CRAP principles.
+- Explain the FAIR principles.
+
+# 📚 Readings
+
+To prepare, check out the following resources:
+
+- 📘 [R for Data Science — Communication](https://r4ds.hadley.nz/communication.html)
+- 📘 [Guide to good practices for data scientists (government of Luxembourg)](https://mindigital.temporel.lu/dam-assets/publications/guide-manuel/guide-data-scientists/fr-guide-de-bonnes-pratiques.pdf)
+
+# 🧭 Adventure
+
+You will play a **data ethics expert** and will be responsible for evaluating a problematic report.\
+Link to the adventure:\
+👉 [Adventure 7 — Visualization, ethics and data security](aventure.qmd)
+
+# 💡 Challenge — Ethical analysis and responsible visualization {.unnumbered}
+
+You will receive a simulated COVID dataset. Your task will be to produce responsible analysis:
+
+- Evaluate the ethical aspects related to the visualization provided.
+- Properly anonymize the data.
+- Create a new faithful and informative visualization.
+- Write a critical reflection on the issues encountered.
+
+# 🏋️ Consolidation exercises {.unnumbered}
+
+Here are some real-world examples of problematic or controversial visualizations to analyze:
+
+1. **Fox News – Graphic on Christianity in the United States**\
+    The channel broadcast a graph with a truncated Y axis, visually exaggerating a decline in the unemployment rate.
+
+    ![](resources/clipboard-894012077.png)
+
+    **➤ Question**: How does the shape of the axis mislead the reader? How to represent it honestly?
+
+2. **USA Today – Wrong pie chart**\
+    The graph totals more than 100% shares, making the visualization inconsistent.
+
+    ![](resources/clipboard-2969921414.png)\
+    **➤ Question**: What does this error show? What types of alternative charts would work best?
+
+3. **American electoral maps – Surface distortion**\
+    Large, sparsely populated rural areas are visually dominant on maps, even if they have few voters.
+
+    ![](resources/clipboard-2149490763.png)\
+    **➤ Question**: Why can geographic size distort the perception of results? How to do better?
+
+4. **Ticked Axis – Educational example of manipulation**\
+    Two versions of the same graph, one honest and the other manipulated by axis truncation, reveal the impact of visual choices.
+
+    \
+
+    ![Lesson 3: Apply the Information \| Critical Thinking Course \| Learn ...](https://giencprograms.blob.core.windows.net/lms/uploads/ceu-course/truncated-y.png){alt="Lesson 3: Apply the Information | Critical Thinking Course | Learn ..."}\
+    **➤ Question**: What do you notice when comparing the two versions? What different messages are conveyed?
+
+5. **Cambridge Analytica – Psychological profiling without consent**\
+    Facebook data used without users' knowledge for electoral manipulation purposes.\
+    <https://fr.wikipedia.org/wiki/Cambridge_Analytica>\
+    **➤ Question**: What ethical principles are violated here (transparency, consent, anonymization)? How to prevent this type of drift?

--- a/en/module_08/aventure.qmd
+++ b/en/module_08/aventure.qmd
@@ -1,0 +1,260 @@
+---
+title: "Adventure 8 - Open data from Quebec"
+subtitle: "STT-1100 Introduction to Data Science"
+author:
+  - institute: “Laval University”
+editor:visual
+editor_options:
+  chunk_output_type: console
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    css: [../css/base_css.css]
+    self-contained: true
+---
+
+```{r setup, include=FALSE}
+library(tidyverse)
+library(rvest)
+library(purrr)
+```
+
+# 🎬 Scenario: Immerse yourself in the shoes of a freelance consultant
+
+You work as a **freelancer** in data science. Unlike a salaried position, you are mandated from time to time by clients to resolve specific problems. You must be autonomous, rigorous and capable of delivering effective, reusable and well-documented solutions.
+
+Freelance consultants are often called upon for their ability to unblock projects quickly and efficiently. They deliver tools that are well documented, testable, and easy to maintain by their customers. Clarity of the code, respect for standards and ethics are therefore key elements of their practice.
+
+Today, you are hired by **Marie-Pier**, research director at the Quebec Institute for Sustainable Data. She wishes to explore the [dataquebec.ca](https://www.donneesquebec.ca) portal to identify the most recent and relevant datasets for her projects. Your mission: **design a reliable scraping tool** to extract titles, producers and categories from datasets, while respecting good ethical practices.
+
+::: callout-note
+**Your contact: Marie-Pier**\
+She accompanies you throughout this adventure: she will ask key questions, check your results, and help you refine your deliverables.
+:::
+
+## Adventure Objectives
+
+- Understand the basics of web scraping with `rvest`.
+- Create a function to extract metadata from a web page.
+- Automate extraction on multiple pages.
+- Explore trends in Quebec open data.
+- Evaluate the ethical and technical feasibility of scraping other websites.
+
+----------------------------------------------------------------------------------
+
+# 📚 Prerequisites
+
+::: {.callout-important title="🧑‍💼 - Question from Marie-Pier"}
+*“What can we legally extract from this portal? Is scraping allowed here? »*
+:::
+
+To answer this question, we will first consult the site's `robots.txt` file. This file indicates the rules that indexing (and therefore scraping) robots must follow.
+
+```{r exploration-ethics}
+# Show robots.txt
+robots <- readLines("https://www.donneesquebec.ca/robots.txt")
+cat("\nContents of robots.txt file:\n")
+writeLines(robots)
+
+# Quick analysis
+disinstructions <- robots[grepl("^Disallow", robots)]
+cat("Paths prohibited for robots:\n")
+writeLines(disinstructions)
+
+# Ethics note
+cat("\n\n\u2139\ufe0f Note:\nPublic datasets listed in the result pages are not explicitly restricted.\nScraping of main search pages is therefore permitted, as long as we avoid the paths /api/, /dataset/rate/, etc.\n")
+
+```
+
+# 📚 Understanding web scraping with `rvest`
+
+In this section, you will discover the essential functions of the `rvest` package. Your goal: learn how to extract structured HTML content from a website.
+
+```{r reading-html}
+url <- "https://www.donneesquebec.ca/recherche/?sort=metadata_modified+desc&page=1"
+page <- read_html(url)
+page
+```
+
+The `read_html()` function downloads and converts the web page to allow manipulation.
+
+Marie-Pier asks you:
+
+::: {.callout-important title="🧑‍💼 - Question from Marie-Pier"}
+*“Can you show me what the structure of this page looks like? Can you spot anything interesting? »*
+:::
+
+We can now target HTML elements with `html_nodes()` (or `html_elements()` in recent versions):
+
+```{r test-nodes}
+blocks <- html_nodes(page, ".dataset-content")
+length(blocks)
+blocks[[1]]
+```
+
+To extract text from an HTML node:
+
+```{r test-text}
+html_text(blocks[[1]])
+```
+
+Now, let's test the extraction of the **title**:
+
+```{r test-title}
+html_nodes(blocks[[1]], ".dataset-heading a") %>% html_text(trim = TRUE)
+```
+
+And for the **producers**? It is necessary to identify a substructure containing the information:
+
+```{r test-producer}
+orgs <- html_nodes(blocks[[1]], ".dqc-org-cat") %>% html_text(trim = TRUE)
+orgs
+```
+
+We can filter the good element with `grepl()` then clean the string with `gsub()`:
+
+```{r extract-producer}
+org <- orgs[grepl("^Organization", orgs)][1]
+org_clean <- gsub("^Organization: ", "", org)
+org_clean
+```
+
+::: callout-tip
+💡 **Why use `map_chr()`?**\
+`map_chr()` belongs to the **purrr** package, which is part of the `tidyverse`. This function allows you to apply a function to each element of a list (here each HTML block), and to return a character vector. This is perfect when you want one text value per block.
+
+> Example:
+>
+> ``` r
+> producers <- map_chr(blocks, function(block) {
+> orgs <- html_nodes(block, ".dqc-org-cat") %>% html_text(trim = TRUE)
+> org <- orgs[grepl("^Organization", orgs)][1]
+> gsub("^Organization: ", "", org)
+> })
+> ```
+:::
+
+::: callout-tip
+💡 **It's up to you**: From this same HTML block, find how to extract: - the **categories** associated with each dataset
+:::
+
+----------------------------------------------------------------------------------
+
+# ✏️ Guided creation of the `scrape_page()` function
+
+Marie-Pier wants you to create a reusable function named `scrape_page()` which takes a URL as an argument and returns a `data.frame` with the columns: `title`, `producer`, `category`.
+
+Here is a skeleton to complete:
+
+```{r, eval=FALSE}
+scrape_page <- function(url) {
+  # Read the HTML content of the page
+  page <- read_html(url)
+
+  # Select individual result blocks
+  blocks <- html_nodes(page, ".dataset-content")
+
+  # Title (already done for you)
+  titles <- html_nodes(blocks, ".dataset-heading a") %>% html_text(trim = TRUE)
+
+  # Producer (to be completed)
+  producers <- map_chr(blocks, function(block) {
+    #... your code here...
+  })
+
+  # Category (to be completed)
+  categories <- map_chr(blocks, function(block) {
+    #... your code here...
+  })
+
+  # Create a standard data.frame
+  data.frame(
+    title = titles,
+    producer = producers,
+    category = categories,
+    stringsAsFactors = FALSE
+  )
+}
+```
+
+::: callout-note
+💡 **Test your function with page 3**: it should return the 20 datasets on this page.
+:::
+
+----------------------------------------------------------------------------------
+
+# 🔁 Manual repeat, then `for` loop
+
+Now test the extraction of the **first 5 pages** by calling your function several times:
+
+```{r, eval=FALSE}
+# Manual example (to be completed)
+p1 <- scrape_page("...")
+p2 <- scrape_page("...")
+# etc.
+```
+
+::: callout-tip
+💬 **Marie-Pier**: “Have you noticed what changes in the URL each time? Can you generalize this behavior? »
+:::
+
+Reminder of **module 1**: a loop allows you to automate repetitive behavior. Here is the start of a `for` loop to complete:
+
+```{r, eval=FALSE}
+results <- data.frame()
+
+for (i in 1:5) {
+  # Build URL here
+  url <- "..."
+
+  cat("Page", i, "current...\n")
+  page_data <- scrape_page(url)
+
+  results <- bind_rows(results, page_data)
+  Sys.sleep(1)
+}
+```
+
+----------------------------------------------------------------------------------
+
+# 🔍 Exploration guided by Marie-Pier
+
+Use the `results` table to answer your client's questions. She expects precise results from you, illustrated if necessary.
+
+::: {.callout-important title="🧑‍💼 - Questions from Marie-Pier"}
+1. What are the most common categories of datasets?
+2. Which organizations publish the most?
+3. Are we observing a diversity of fields or a concentration on a few themes?
+:::
+
+----------------------------------------------------------------------------------
+
+# 🤔 Ethical reflection
+
+::: {.callout-note title="💡 For your report"}
+Briefly report:
+
+- Does the Data Québec site explicitly allow scraping?
+- What behaviors have you adopted to remain respectful?
+- Choose **two other websites** (ex: bonjourquebec.com, ulaval.ca) and check if scraping seems authorized or not. Rely on the `robots.txt` files or terms of use.
+:::
+
+----------------------------------------------------------------------------------
+
+# 🧪 Challenge to submit
+
+You must submit a **file `IDUL.R`** containing your `scrape_page()` function.
+
+- This file should be placed in your GitHub repository in the location indicated.
+- We will automatically test your function with multiple pages.
+
+🎯 Good luck — be rigorous in your function design!
+
+----------------------------------------------------------------------------------
+
+# ✅ Conclusion of the adventure
+
+You've designed a functional, automated scraping tool, used a `for` loop, extracted structured metadata, and deepened your understanding of the ethics of scraping.
+
+Well done, consultant! 🧠💻

--- a/en/module_08/plan_apprentissage.qmd
+++ b/en/module_08/plan_apprentissage.qmd
@@ -1,0 +1,65 @@
+---
+title: "Module 8 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Module objectives
+
+At the end of this module, you should be able to:
+
+- Extract text data from a web page using `rvest`.
+- Automate repetitive tasks using loops and functions in R.
+- Identify the ethical aspects linked to the automated collection of online data.
+
+# 📚 Readings
+
+To prepare, check out the following resources:
+
+- 📘 [R for Data Science — Web scraping](https://r4ds.hadley.nz/webscraping.html)
+- 📘 [robots.txt documentation (MDN)](https://developer.mozilla.org/en-US/docs/Glossary/Robots.txt)
+
+# 🧭 Adventure
+
+You play the role of a **freelance consultant** hired to develop an automated metadata extraction function from the Data Québec portal.\
+Link to the adventure:\
+👉 [Adventure 8 — Quebec open data](aventure.qmd)
+
+# 💡 Challenge — Scraping function {.unnumbered}
+
+You will need to design a function `scrape_page(url)` which:
+
+- takes as input a URL from a Data Québec search page;
+- returns a `data.frame` with the columns `title`, `producer`, `category`.
+
+📁 You will put this function in an `IDUL.R` file in your GitHub repository. It will be tested automatically on several pages.
+
+# 🏋️ Consolidation exercises {.unnumbered}
+
+These exercises use a **different page** of the Data Québec portal, in order to practice in another context.\
+Use the archived version of the IMDb Top 250 Movies page: 👉 <https://web.archive.org/web/20220201012049/https://www.imdb.com/chart/top/>
+
+1. **Read the HTML page**\
+    ➤ Use `read_html()` then `html_nodes()` to observe the sections containing the movie titles.
+
+2. **Extract movie titles**\
+    ➤ Try `html_nodes(..., ".titleColumn a") %>% html_text()`.
+
+3. **Extract the years**\
+    ➤ Use `html_nodes(..., ".titleColumn span")` to extract the years in parentheses.
+
+4. **Extract notes**\
+    ➤ Use `html_nodes(..., ".imdbRating strong")` to get the ratings for each movie.
+
+5. **Build a table**\
+    ➤ Combine the three vectors (`title`, `year`, `note`) into a `data.frame`.
+
+6. **Ethical reflection**\
+    ➤ Check if the IMDb page archive (or IMDb directly) allows scraping by consulting their [robots.txt](https://www.imdb.com/robots.txt).

--- a/en/module_09/aventure.qmd
+++ b/en/module_09/aventure.qmd
@@ -1,0 +1,188 @@
+---
+title: "Adventure 9 - Algorithmic prediction and bias"
+subtitle: "STT-1100 Introduction to Data Science"
+author:
+  - institute: “Laval University”
+editor:visual
+editor_options:
+  chunk_output_type: console
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    css: [../css/base_css.css]
+    self-contained: true
+---
+
+```{r setup, include=FALSE}
+library(tidyverse)
+```
+
+# 🎬 Scenario: Quality control in education
+
+You work as a **junior data scientist** in the quality control and equity department at the Quebec Ministry of Education. Your mandate: use real and fictitious data to identify, evaluate and mitigate algorithmic bias in educational decisions.
+
+Your superior, **Michel Dufour**, deputy director of the department, welcomes you with these words:
+
+> “Welcome to the team!” Our work is crucial: ensuring that every child has equal opportunities to succeed. To do this, we not only need to effectively predict certain indicators, but also understand and avoid biases in our models. »
+
+::: callout-note
+**Your contact: Michel Dufour**\
+He will accompany you on this adventure: he will ask key questions and await your results and detailed analyses.
+:::
+
+## Adventure Objectives
+
+- Build a clear predictive model from real data.
+- Identify and explain potential biases on fictitious data.
+- Clearly present your analyzes and thoughts on these biases.
+- Propose concrete recommendations to mitigate these biases.
+
+----------------------------------------------------------------------------------
+
+# 📚 Mission 1: Predictive model at school level
+
+Michel gives you a [data file from the Data Québec portal](https://www.donneesquebec.ca/recherche/dataset/indices-de-defavorisation/resource/6c5d4a5d-ba3b-40a6-b570-916f43ab622c). These data contain information on disadvantage on primary schools in Quebec.
+
+::: {.callout-important title="🧑‍💼 - Michel explains to you"}
+“I invite you to explore the data. But be careful: the column names are not always intuitive. Start by visiting the documentation page on Data Québec to fully understand their meaning. »
+:::
+
+## Step 1: Exploration and cleaning
+
+- Identify relevant variables.
+- Do a summary cleanup if necessary (missing values, data types, etc.).
+- Carry out a complete descriptive analysis of this data (refer to modules 2 to 4).
+
+```{r data-load, eval=FALSE}
+# df_ecoles <- read_csv("ecoles_primaires_qc.csv") # File missing
+glimpse(df_schools)
+```
+
+## Step 2: Regression Model
+
+::: {.callout-important title="🧑‍💼 - Michel asks you"}
+“I would like you to build a linear regression model to predict the **IMSE** (Socio-Economic Environment Index), based on two variables: the proportion of low-income students (**SFR**) and the **total number of students** in the school. »
+:::
+
+```{r regression, eval=FALSE}
+model <- lm( ... , data = ...)
+summary(model)
+```
+
+::: {.callout-important title="🧑‍💼 - Michel questions you"}
+“Once the model is built, can you explain to me, in simple language, what the two coefficients mean? »
+:::
+
+## Step 3: Targeted Predictions
+
+You will then use the `predict()` function to generate IMSE predictions from your model.
+
+```{r prediction-example, eval=FALSE}
+predict(model, newdata = df_schools)
+```
+
+::: {.callout-important title="🧑‍💼 - Michel specifies"}
+“I would like you to use your template to:”
+
+\- predict the IMSE for the **10 largest schools** (in number of students);
+
+\- predict the IMSE for the **10 schools with the highest SFRs**.
+
+Compare predicted values ​​to actual values. Is your model good?
+:::
+
+## Step 4: Missing School Predictions
+
+::: {.callout-important title="🧑‍💼 - Michel adds"}
+“Last thing: in the data, some schools have the variable **Diffusion** set to “NO”. These schools do not have a measured IMSE — often because they have fewer than 30 students. »
+
+“Can you use your model to **predict the IMSE of all schools with fewer than 30 students**? Next, I would like to know: what do you think about the validity of these predictions? Can we trust it? »
+:::
+
+----------------------------------------------------------------------------------
+
+# 📊 Mission 2: Detection of individual biases
+
+Michel also provides you with a fictitious dataset of 1000 students. At first glance, this game seems neutral. But is this really the case?
+
+Load the data:
+
+```{r dummy-load, eval=FALSE}
+df_students <- read_csv("students_fictifs.csv")
+glimpse(df_students)
+```
+
+### Step 1: Overall analysis
+
+Start by calculating and visualizing the **overall admission rate**.
+
+```{r admission-global, eval=FALSE}
+df_students %>%
+  count(Admission) %>%
+  mutate(pct = n / sum(n))
+```
+
+Discuss what you observe: is it balanced? Surprising?
+
+### Step 2: Analysis by group
+
+Now, explore admission rates **by gender**.
+
+```{r admission-by-sex, eval=FALSE}
+# code to modify
+df_students %>%
+  count(Admission) %>%
+  group_by(Sex) %>%
+  mutate(pct = n / sum(n))
+```
+
+Produce a clear graph to illustrate potential differences.
+
+### Step 3: Guided discussion
+
+- Do you see a notable difference between the groups?
+- Is this difference justified? What assumptions can you make?
+- Can we talk about **bias** here? For what ?
+
+### Step 4: Exploring other variables
+
+Then continue with the analysis according to other variables (mother tongue, socio-economic level, access to resources).
+
+You can reproduce the same logic: crosstab + graph + interpretation.
+
+**To be submitted:** a brief summary presenting the bias(es) detected, with clear visual support and recommendations or avenues for improvement.
+
+----------------------------------------------------------------------------------
+
+# 📹 Challenge to submit
+
+You will have to produce a **video capsule of 180 seconds maximum** in which you present:
+
+- Or your predictive model based on real data (Mission 1).
+- Either your analysis of the bias detected from the fictitious data (Mission 2).
+
+Your capsule must include:
+
+- A short introduction (put into context).
+- Your methodology briefly explained.
+- Your results presented visually (tables, graphs).
+- A clear conclusion with recommendations or avenues for improvement.
+
+Your video capsule must be uploaded to the indicated GitHub repository.
+
+::: callout-tip
+🎯 **Tips for making your video successful:**
+
+- Be concise and clear.
+- Rely on readable graphics.
+- Speak slowly, clearly, and be dynamic!
+:::
+
+----------------------------------------------------------------------------------
+
+# ✅ Conclusion of the adventure
+
+You have built a predictive model useful for decision making and learned to detect critical biases in individual data.
+
+Bravo for your rigor, your sense of observation and your ethical posture! 🎉📊

--- a/en/module_09/plan_apprentissage.qmd
+++ b/en/module_09/plan_apprentissage.qmd
@@ -1,0 +1,132 @@
+---
+title: "Module 9 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Module objectives
+
+At the end of this module, you should be able to:
+
+- Fit and interpret a simple linear regression model.
+- Use a simple linear regression model to obtain predictions.
+- Fit and interpret a multiple linear regression model.
+- Recognize and discuss potential biases, particularly those related to discrimination, in data or models.
+
+# 📚 Readings
+
+To prepare, check out the following resources:
+
+- 📘 [Introduction to Modern Statistics – Chapter 7: Linear regression with a single predictor](https://openintro-ims.netlify.app/model-slr)
+
+- 📘 [Introduction to Modern Statistics – Chapter 8: Linear regression with multiple predictors](https://openintro-ims.netlify.app/model-mlr)
+
+- 📘 [Introduction to Modern Statistics – Chapter 25: Inference for linear regression with multiple predictors - section 1](https://openintro-ims.netlify.app/inf-model-mlr#sec-inf-mult-reg-soft)
+
+# 🧭 Adventure
+
+You play the role of a **data scientist** within the Quebec Ministry of Education. Your mandate is twofold: build a predictive model from primary school data, then explore a fictitious dataset to detect bias.
+
+👉 [Adventure 9 — Algorithmic prediction and bias](aventure.qmd)
+
+# 💡 Challenge — Video capsule {.unnumbered}
+
+You must produce a **180-second video capsule** in which you present:
+
+- either a predictive model built in Mission 1;
+- or a critical analysis of a bias detected in Mission 2.
+
+🎯 The capsule must include:
+
+- a clear introduction;
+
+- a brief methodology;
+
+- visual results (graphs, tables);
+
+- a conclusion with at least one recommendation.
+
+# 🏋️ Consolidation exercises {.unnumbered}
+
+Here is an integrative exercise based on the `penguins` dataset from the `palmerpenguins` package. It combines modeling, interpretation and critical thinking.
+
+## 🐧 Study of penguin body mass
+
+You work for an environmental NGO that wants to better understand the factors influencing the body mass of penguins in Antarctica. You have the `penguins` dataset, cleaned using the `drop_na()` function to avoid missing values.
+
+``` r
+library(palmerpenguins)
+library(tidyverse)
+
+df <- penguins %>% 
+  drop_na()
+```
+
+### 1. Visualization and hypothesis
+
+Trace the relationship between `body_mass_g` and `flipper_length_mm`. Does a linear relationship seem plausible to you?
+
+<details>
+
+<summary>💡 Solution</summary>
+
+Use `ggplot(df, aes(x = flipper_length_mm, y = body_mass_g)) + geom_point() + geom_smooth(method = "lm")`. The relationship is clearly linear.
+
+</details>
+
+### 2. Simple regression
+
+Fit a `body_mass_g~flipper_length_mm` model. Interpret the slope.
+
+<details>
+
+<summary>💡 Solution</summary>
+
+Each additional mm of fin length is associated with an average increase of X grams of body mass (see exact value in the model).
+
+</details>
+
+### 3. Multiple regression
+
+Now adjust `body_mass_g ~ flipper_length_mm + sex`. What is the reference variable? What differences do you observe?
+
+<details>
+
+<summary>💡 Solution</summary>
+
+R uses the first alphabetical modality as a reference (here probably "female"). The `sexmale` coefficient represents the average difference in mass between males and females, at equal length.
+
+</details>
+
+### 4. Targeted Predictions
+
+Predict the body mass for a penguin with 200 mm fin length, male.
+
+<details>
+
+<summary>💡 Solution</summary>
+
+Create a table `newdata <- tibble(flipper_length_mm = 200, sex = "male")` then do `predict(model, newdata)`.
+
+</details>
+
+### 5. Critical thinking
+
+Is the `species` variable relevant to include? What precaution should you take if you add it?
+
+<details>
+
+<summary>💡 Solution</summary>
+
+Yes, `species` is highly correlated with mass. Attention should be paid to multicollinearity if it is strongly related to other predictors.
+
+</details>
+
+Happy exploring!

--- a/en/module_10/aventure.qmd
+++ b/en/module_10/aventure.qmd
@@ -1,0 +1,275 @@
+---
+title: "Adventure 10 — Beyond data: text and dashboard"
+subtitle: "STT-1100 • Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: "Adventure plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../css/base_css.css]
+editor:visual
+editor_options:
+  chunk_output_type: console
+---
+
+# ✈️ Put in context
+
+This week, you were **hired as a junior business analyst** by the **Faculty of Science and Engineering at Laval University**. As part of the reform of the baccalaureate in statistics and data science, management wishes to evaluate **the evolution of student feelings throughout the session**.
+
+Each week, students answered a questionnaire about their learning experience in the STT-1100 course. Your analyzes will be essential to document the strengths and areas for improvement of the new program.
+
+You are guided by **Anne-Sophie**, the program director, who supports you in structuring your dashboard and helps you interpret the results.
+
+> “The idea is to have an honest, but constructive portrait. We want to see the underlying trends and draw inspiration from them to continue to improve our program.”
+
+# 🎯 Mission
+
+Build an interactive dashboard (with `flexdashboard` and `shiny`) which allows you to:
+
+- view the feelings expressed per week,
+- identify the most frequent and distinctive words,
+- explore lexical trends over time,
+- offer dynamic filters to refine the analysis.
+
+# 📁 Data
+
+A `sentiments_cours.csv` file contains:
+
+- `id`: anonymous identifier
+- `week`: week number
+- `comment`: free text on their feelings about the course this week
+- `difficulty`: perceived level of difficulty (1 to 5)
+- `engagement`: engagement level (1 to 5)
+- `pleasure`: pleasure level (1 to 5)
+
+# 🧰 Recommended tools
+
+- `tidytext`, `stringr`, `dplyr`: text cleaning and analysis
+- `ggplot2`, `wordcloud`, `plotly`: visualization
+- `flexdashboard`, `shiny`: interactive interface
+- `lexicon`: `bing`, `afinn`, or `nrc` (for sentiment analysis)
+
+# 🧪 Guided steps
+
+## Step 1 — Text Cleanup
+
+::: {.callout-important title="🧑‍💼 - Question from Anne-Sophie"}
+“Could you show me an example with some comments and how you would clean them step by step? »
+:::
+
+::: {.callout-tip title="🧑‍💼 - Little reminder"}
+Text cleaning is essential before any analysis. You want every word to have a relevant meaning. Try to remove punctuation, common words, and make sure everything is in lowercase.
+:::
+
+::: {.callout-note title="🔎 Key concepts"}
+- **Tokenization**: process which consists of cutting the text into basic units (words, n‑grams). Each token becomes a row in your table.
+- **Stopwords**: very frequent words ("the", "of", "and", etc.) which generally do not provide useful semantic information for analysis.
+- **Cleaning**: lowercase, removal of punctuation, numbers and special characters to standardize tokens.
+:::
+
+### Example of simulated dataset
+
+```{r}
+# Fictitious dataset in French with comments
+example <- tibble::tibble(
+  id = 1:7,
+  week = c(1, 1, 2, 2, 2, 3, 3),
+  comment = c(
+    “I found the course very clear this week, well done to the teacher!”,
+    “I’m starting to understand better, it’s motivating!”
+    “Too much material to assimilate in a short time, I feel overwhelmed.”,
+    “Not easy this week, I had trouble with the graphics.”,
+    "Phew very difficult this week, especially with the graphics.",
+    “The tools are powerful, but I lack practice.”,
+    “The construction of the dashboard is super interesting.”
+  )
+)
+```
+
+### Text preprocessing
+
+```{r message=FALSE, warning=FALSE}
+library(tidytext)
+library(dplyr)
+library(stringr)
+library(tibble)
+library(ggplot2)
+library(stopwords)
+
+# Load French stopwords
+stop_fr <- stopwords::stopwords("fr", source = "snowball")
+
+clean_text <- example %>%
+  unnest_tokens(word, comment) %>%
+  filter(!word %in% stop_fr, # Remove frequent words
+         str_detect(word, "^[a-zéèêàâîôûùçäëïöü]+$")) # Keep words valid in French
+
+head(clean_text)
+```
+
+::: {.callout-important title="🧑‍💼 - Question from Anne-Sophie"}
+“Could you show me an example with some comments and how you would clean them step by step? »
+:::
+
+Anne-Sophie asks you to apply a classic cleanse:
+
+- remove punctuation, numbers and frequent words (stopwords),
+
+- transform the text into lowercase,
+
+- **tokenize** the text (cut into words).
+
+## Step 2 — Sentiment Analysis
+
+We are interested here in the **emotional valence** of the words in the comments. Sentiment analysis allows you to quantify whether a text is rather positive or negative.
+
+::: {.callout-note title="🔎 Key concepts"}
+- **Sentiment of a word**: label (positive, negative) or numerical score indicating the emotional valence of the word.
+- **Sentiment score of a text**: sum or difference of the scores/labels of the words it contains, often aggregated by document or, here, by week.
+:::
+
+### Sentiment analysis in French
+
+Currently, there **does not exist a lexicon integrated into `tidytext::get_sentiments()` for French** (unlike English, where the lexicons `bing`, `afinn`, and `nrc` are directly accessible). Here is an educational approach: create a small personalized glossary to enrich in class.
+
+::: {.callout-important title="🧑‍💼 - Suggestion from Anne-Sophie"}
+“For this step, I recommend that you build a little homemade lexicon. You can start with words that come up often and rank them subjectively. The goal here is to understand the principle of sentiment analysis, even with simple tools. »
+:::
+
+```{r}
+# Basic house glossary to adapt
+lexicon_fr <- tibble::tibble(
+  word = c("clear", "motivating", "well done", "difficult", "outdated", "bad", "interesting", "powerful"),
+  feeling = c("positive", "positive", "positive", "negative", "negative", "negative", "positive", "positive")
+)
+
+sentiment_fr <- clean_text %>%
+  inner_join(lexique_fr, by = "word") %>%
+  count(week, sentiment) %>%
+  tidyr::pivot_wider(names_from = sentiment, values_from = n, values_fill = 0) %>%
+  mutate(score = positive - negative)
+
+sentiment_en
+```
+
+### Viewing scores per week
+
+Let's make a graph to visualize the evolution of the sentiment score per week:
+
+```{r}
+ggplot(sentiment_fr, aes(x = week, y = score)) +
+  geom_col(fill = "steelblue") +
+  labs(title = "Feeling score per week",
+       y = "Net score (positive - negative)", x = "Week")
+```
+
+::: {.callout-note title="🧑‍💼 - Advice from Anne-Sophie"}
+“As the lexicons integrated into `get_sentiments()` are only available in English, I suggest you build a small homemade lexicon for French. It will be imperfect, but it will help you understand the principle. We can then discuss it together to enrich it. What interests me is that you are able to interpret the evolution of sentiment from one week to the next, even with simple tools. »
+:::
+
+### 🤝 Final collaboration
+
+At the end of the course, an in-class activity will allow each student/team to **share their own lexicon of feelings in French** built during the analysis.
+
+🎓 **The teacher will collect and merge these lexicons**, checking them to obtain a common enriched version. This new version will be shared with the whole class as a collective resource for future projects.
+
+## Step 3 — Distinctive words
+
+In this step, we will identify the words that stand out the most each week. To do this, we will use the **TF-IDF** (Term Frequency-Inverse Document Frequency) approach, which allows us to highlight words that are both frequent in a document and rare in all documents.
+
+::: {.callout-tip title="🧑‍💼 - Idea from Anne-Sophie"}
+“A good indicator of how students feel is the words that stand out the most in their comments. You can try a TF-IDF analysis or even create a word cloud. »
+:::
+
+::: {.callout-note title="🔎 Key concepts"}
+- **TF (Term Frequency)**: frequency of appearance of a word in a document.
+- **IDF (Inverse Document Frequency)**: inverse importance of a word in all documents – rare words have a high IDF.
+- **TF‑IDF**: TF × IDF product which highlights words that are both frequent in a document and rare in others ("distinctive" words).
+:::
+
+### TF-IDF calculation
+
+Let's calculate the TF-IDF for each word per week:
+
+```{r}
+tfidf <- clean_text %>%
+  count(week, word) %>%
+  bind_tf_idf(word, week, n) %>%
+  arrange(desc(tf_idf))
+
+head(tfidf)
+```
+
+### Visualization for a given week
+
+Let's make a chart to visualize the most distinctive words for a specific week. For example, week 2:
+
+```{r}
+# Choose week 2 as an example
+library(forcats)
+
+tfidf %>%
+  filter(week == 2) %>%
+  slice_max(tf_idf, n = 8) %>%
+  mutate(word = fct_reorder(word, tf_idf)) %>%
+  ggplot(aes(x = word, y = tf_idf)) +
+  geom_col(fill = "darkorange") +
+  coordinate_flip() +
+  labs(title = "Most Distinctive Words — Week 2",
+       x = NULL, y = "TF-IDF")
+```
+
+A visualization like this allows you to see which words are most representative of that week's comments. There is also the possibility of creating a **word cloud** for a more visual representation. A word cloud is a graphical representation of the most frequent words, where the size of each word is proportional to its frequency of occurrence.
+
+💡 To create a word cloud in French: - Use the `wordcloud()` function of the `wordcloud` package, or `ggwordcloud` for more customization. - Get inspired by this complete example: <https://cran.r-project.org/web/packages/wordcloud2/vignettes/wordcloud.html>
+
+::: {.callout-important title="🧑‍💼 - Question from Anne-Sophie"}
+“Can you spot the words that stand out the most each week? You could try a TF-IDF approach and make me a graph or even a word cloud. »
+:::
+
+## Step 4 — Creating the dashboard
+
+Now that we've cleaned the data and performed the sentiment and distinguishing words analyses, it's time to create an interactive dashboard. This will allow Anne-Sophie to visualize the results in a clear and dynamic way.
+
+::: {.callout-note title="🧑‍💼 - Reminder of Anne-Sophie"}
+The final dashboard should be **clear, interactive and useful**. A **ready-to-use template (`Modele_Dashboardt.Rmd`)** can be found in the module's GitHub repository. Customize it: plug in your own data, adjust filters, and add at least two visualizations.
+:::
+
+## Step 5 — Recommendations and final analysis
+
+At the end of the dashboard, write a summary of your **key observations**:
+
+- evolution of the sentiment score,
+- critical weeks,
+- recommendations for action to improve the student experience,
+- **analysis of numerical variables** `difficulty`, `engagement`, `pleasure`: average and trend per week, comparison with the sentiment score (e.g. simple correlations or combined graphs).
+
+::: {.callout-important title="🧑‍💼 - Anne-Sophie Challenge"}
+“Don’t forget to explore the numerical scores. How does text sentiment compare to level of perceived enjoyment or difficulty? Present at least one visualization that cross-references this information. »
+:::
+
+# 🌟 Bonus — Personalization — Personalization
+
+Here are some ideas to go further in customizing your dashboard:
+
+- Add the **logo of the Faculty of Science and Engineering** or Laval University,
+- Customize the **color palette** so that it is consistent with the ULaval visual identity,
+- Add a discreet **background photo** in the header,
+- Add an inspirational quote or greeting in the sidebar.
+
+💡 You can also integrate a progress bar or visual indicator of overall sentiment per week.
+
+# 📤 Delivery expected
+
+- A GitHub repository containing:
+    - the `.Rmd` of the dashboard,
+    - the final HTML rendering,
+    - the cleaned data file (if modified).
+- **The dashboard must be deployed (for example via Shinyapp.io or Posit Cloud)** and the final link sent to **Anne-Sophie (the real program director)**.
+
+# 🧠 Advice from Anne-Sophie
+
+> “A good dashboard is like a good pitch: **clear, readable and targeted**. Put yourself in your end user's shoes. »

--- a/en/module_10/plan_apprentissage.qmd
+++ b/en/module_10/plan_apprentissage.qmd
@@ -1,0 +1,63 @@
+---
+title: "Module 10 - Learning plan"
+subtitle: "STT-1100 Introduction to Data Science"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+    css: [../css/base_css.css]
+editor:visual
+---
+
+# 🎯 Module objectives
+
+At the end of this module, you should be able to:
+
+- Clean and analyze textual data.
+- Build a simple sentiment lexicon in French.
+- Visualize lexical and emotional trends over time.
+- Use TF-IDF to identify distinctive words.
+- Create an interactive dashboard with `flexdashboard` and `shiny`.
+
+# 📚 Readings
+
+To prepare, check out the following resources:
+
+- 📘 [Tidytext Text Mining](https://www.tidytextmining.com/) – Chapters 1 to 3 - This book introduces you to the basics of word processing with R.
+- 📘 [Flexdashboard documentation (RStudio)](https://rmarkdown.rstudio.com/flexdashboard/) - this document guides you in creating interactive dashboards with `flexdashboard`.
+- 📘 [Shiny for dashboards](https://rstudio.github.io/flexdashboard/using.html#shiny_interaction) - This guide shows you how to integrate interactive elements into your dashboards with `shiny`.
+
+# 🧭 Adventure
+
+You are a junior business analyst hired by the Faculty of Science and Engineering at Laval University. Your mandate: analyze anonymous student comments on the STT-1100 course and produce an interactive dashboard for program management.
+
+👉 [Adventure 10 — Beyond data: text and dashboard](aventure.qmd)
+
+# 💡 Challenge — Deployed Dashboard {.unnumbered}
+
+You need to build an interactive dashboard from the template provided. This dashboard must:
+
+- Display a sentiment score per week;
+- Identify distinctive words (TF-IDF) or a word cloud;
+- Analyze numerical variables (`pleasure`, `commitment`, `difficulty`);
+- Be personalized (filtering, colors, summary);
+- Be deployed and shared with Anne-Sophie.
+
+# 📊 Evaluation grid
+
+Each team must submit an interactive dashboard based on feedback from students in the course. Here is the grid used for the evaluation:
+
+| Criterion | Description | Points |
+|-------------------|--------------------------------------|---------|
+| **Text cleaning** | Text well transformed, tokenized, stopwords removed | /10 |
+| **Lexicon and sentiment score** | Clear construction of the FR lexicon, correct application per week | /15 |
+| **TF-IDF or word cloud** | Clear and well-illustrated analysis of distinctive words | /15 |
+| **Analysis of numerical variables** | Averages or trends well explored (`pleasure`, `difficulty`, etc.) | /15 |
+| **Visualizations** | Readable, relevant, aesthetic graphics | /15 |
+| **Interactive Dashboard (Shiny)** | Effective use of dynamic filters and components | /15 |
+| **Personalization / creative effort** | Adaptation of the model provided, visual and editorial effort | /10 |
+| **Deployment and accessibility** | Functional dashboard, valid link shared on time | /5 |
+
+**Total: /100**

--- a/en/projet_session/enonce_projet.qmd
+++ b/en/projet_session/enonce_projet.qmd
@@ -1,0 +1,194 @@
+---
+title: "Session project — Your first assignment as a data scientist"
+subtitle: "STT-1100 Introduction to Data Science"
+author:
+  - institute: “Laval University”
+format:
+  html:
+    toc: true
+    toc-title: "Project plan"
+    embed-resources: true
+    link-external-newwindow: true
+    code-link: true
+    theme: flatly
+    css: [../css/base_css.css]
+editor:visual
+editor_options:
+  chunk_output_type: console
+---
+
+# 🎯 Your mission
+
+Choose a dataset, any…
+
+…and do something with it.
+
+This, in a nutshell, is your final project.
+
+# 📚 Objective of the project
+
+The final project allows you to demonstrate that you are capable of:
+
+- Ask clear and relevant research questions.
+- Explore and analyze a dataset using the tools learned (RStudio, tidyverse, Quarto).
+- Produce relevant visualizations.
+- Write a reproducible report.
+- Present your results in a clear and structured manner.
+- Collaborate effectively in a GitHub repository.
+
+This project is deliberately open: you have the freedom to choose your data, your angles of analysis, your tools, your methods.
+
+# 🗃️ Dataset
+
+Choose a **manageable** dataset, i.e.:
+
+- At least **50 observations**
+- Between **10 and 20 variables** (exceptions are possible upon approval)
+- Including **continuous numeric**, **discrete** and **categorical** variables
+- Format readable by R (CSV, RDS, etc.)
+
+⚠️ **Avoid datasets seen in class.**
+
+Some useful resources:
+
+- [Quebec data](https://www.donneesquebec.ca/)
+- [TidyTuesday](https://github.com/rfordatascience/tidytuesday)
+- [NHS Scotland Open Data](https://www.opendata.nhs.scot/) - [Edinburgh Open Data](https://edinburghopendata.info/)
+- [Open access to Scotland's official statistics](https://statistics.gov.scot/home)
+- [Bikeshare data portal](https://www.bikeshare.com/data/) - [UK Gov Data](https://data.gov.uk/)
+- [Kaggle datasets](https://www.kaggle.com/datasets) - [OpenIntro datasets](http://openintrostat.github.io/openintro/)
+- [Awesome public datasets](https://github.com/awesomedata/awesome-public-datasets)
+- [Youth Risk Behavior Surveillance System (YRBSS)](https://chronicdata.cdc.gov/Youth-Risk-Behaviors/DASH-Youth-Risk-Behavior-Surveillance-System-YRBSS/q6p7-56au)
+- [PRISM Data Archive Project](https://www.icpsr.umich.edu/icpsrweb/content/ICPSR/fenway.html)
+- [Harvard Dataverse](https://dataverse.harvard.edu/)
+- [Google Dataset Search](https://datasetsearch.research.google.com/)
+- [Canadian govt open data](https://open.canada.ca/en/open-data)
+- [Github Public Dataset](https://github.com/awesomedata/awesome-public-datasets)
+
+# 📦 Project progress
+
+## 1. Proposal — due **Sunday, November 9 at 11:59 p.m.**
+
+Content:
+
+- **Section 1: Introduction**\
+    Present your research questions, your dataset, its provenance, its format, observations and variables.
+
+- **Section 2: Data**\
+    Place your data in the `/data` folder, update the `README`, and include a `glimpse()` or `skim()`.
+
+- **Section 3: Analysis plan**
+
+    - Response and explanatory variables
+    - Comparison groups (if applicable)
+    - First graphs or descriptive stats
+    - Methods considered
+    - Expected results
+
+    Note: This is only a plan. In the next few modules you will learn new methods to analyze your dataset.
+
+> 📏 Max. 1 page per section (excluding graphics).
+
+### Scale (15 points)
+
+| Criterion | Points |
+|--------------------------------------|--------|
+| Data | 5 |
+| Content of the proposal | 8 |
+| Code quality, repository structure | 2 |
+
+## 2. Presentation — to be submitted on **December 15**
+
+Make a **presentation of 15 minutes maximum**, where each member speaks. Use `xaringan` to create your slides. The presentation will take place in class on December 15.
+
+**What you must present:**
+
+- Your questions and why they are interesting
+- Your methodological choices
+- Your main results
+- The limits of your approach
+
+> Hidden code (`echo = FALSE`) unless you want to show part of it.
+
+### Scale (50 points)
+
+| Criterion | Points |
+|-------------------------------------------------------|--------|
+| Time management | 4 |
+| Clarity of the question and relevance of the data | 5 |
+| Professionalism and quality of the oral presentation | 5 |
+| Coherence of teamwork | 6 |
+| Methodological quality | 10 |
+| Creativity and critical thinking | 10 |
+| Visual quality of slides | 10 |
+
+## 3. Final report (`README`) — to be submitted on **December 15, 2025 at 11:59 p.m.**
+
+Provide an executive summary of your project:
+
+- Data set used
+- Objective and research questions
+- Methodology
+- Key results
+
+> 💡 This summary replaces a traditional written report. It must be clear, structured, but concise.
+
+### Scale
+
+| Criterion | Points |
+|---------|--------|
+| Content and clarity | 15 |
+
+# 📁 Organization of the GitHub repository
+
+Expected structure:
+
+`/data <- Dataset and data dictionary`
+
+`/proposal <- Project proposal presentation.Rmd`
+
+`<- Presentation (xaringan) presentation.html`
+
+`<- HTML Presentation README.Rmd + .md`
+
+`<- Final summary`
+
+The deposit must be clean, well structured, and reflect a reproducible approach.
+
+# 🤝 Teamwork
+
+- Mandatory teamwork
+- Fair distribution of work
+- Contribution visible in Git history
+
+You will complete a **peer review** at the end of the project. If a person is deemed inactive (less than 10% contribution), they may receive an adjusted score.
+
+# 🧠 Final evaluation
+
+| Component | Points |
+|--------------------------------|---------|
+| Proposal | 10 |
+| Presentation | 50 |
+| Summary (README) | 15 |
+| Reproducibility, organization | 10 |
+| Peer review | 10 |
+| Peer Review | 5 |
+| **Total** | **100** |
+
+# ✅ What we evaluate
+
+- Quality of questions and data
+- Relevance of statistical methods
+- Clarity of writing and graphics
+- Creativity and critical thinking
+- Respect for good practices (ethics, reproducibility, style)
+
+# 💡 Practical advice
+
+- Start early, test your data access.
+- Commit often, push regularly.
+- Do not hide your code in the `.qmd`, except in the final presentation.
+- Schedule team meetings.
+- Ask questions!
+
+Happy scientific adventure!

--- a/en/references.qmd
+++ b/en/references.qmd
@@ -1,0 +1,246 @@
+---
+title: "Reference material"
+format:
+  html:
+    toc: true
+    toc-title: Plan
+    self-contained: true
+    link-external-newwindow: true
+# number-sections: true
+    css: [css/base_css.css]
+editor:visual
+---
+
+# How to find and get help effectively?
+
+Content to add.
+
+## 🎯 Introduction
+
+A good data scientist doesn’t know everything by heart… but knows **where to look** and **how to ask for help** intelligently. This guide will help you learn how to do it effectively and stress-free.
+
+## 🤖 GPT STT-1100: your personalized assistant
+
+We have designed a **tailor-made GPT wizard for this course**: [GPT STT-1100](https://chatgpt.com/g/g-682d165f32e881918633affa3fe9dfd6-stt-1100)
+
+> He knows the objectives of the course, the modules, the challenges and the libraries used (like `UlavalSSD`). You can ask specific questions related to the course, such as:
+>
+> - *"How to import a `.csv` file with `readr`?"*
+> - *"How to make a graph with `ggplot2` for a numeric variable?"*
+> - *"What are the best practices for writing a reproducible report with Quarto?"*
+
+**Please note:** it does not replace critical thinking! But it is a valuable tool for progressing at your own pace.
+
+## 🧭 Where to look for help?
+
+### 📌 Integrated help in RStudio
+
+- Type `?function` or `help(function)` in the console.
+- Use RStudio's **Help** tab to navigate the documentation.
+- Type `example(function)` to get a ready-made example.
+- Also test the `args(function)` function to see the expected arguments.
+
+### 🌍 Search the web
+
+Billions of answers await you! Here are some tips for properly formulating your research:
+
+::: callout-tip
+**Formulate your questions like a pro:**
+
+- Bad: `it doesn't work with ggplot`
+- Best: `ggplot2 how to add color by group in scatterplot`
+
+**Recommended sites:**
+
+- [Stack Overflow](https://stackoverflow.com)
+- [Posit Community (formerly RStudio Community)](https://community.rstudio.com/)
+- [GitHub](https://github.com/search?q=your+error+message)
+- [Google](https://www.google.com) — type "r ggplot histogram group by color"
+:::
+
+----------------------------------------------------------------------------------
+
+## 📘 Course Resources
+
+### Recommended books and guides
+
+- [**R for Data Science** (2nd ed.)](https://r4ds.hadley.nz/)
+    - Complete guide to understand everything about tidyverse, scripts, graphics, etc.
+- [**The Tidyverse Style Guide**](https://style.tidyverse.org/)
+    - To write clear, clean and understandable code.
+- [**Introduction to Modern Statistics**](https://openintro-ims.netlify.app/)
+    - A complementary reference that emphasizes visualization, modeling, and modern statistics. This book is also free, clear and perfectly suited to beginners.
+- The **Quarto adventures (.qmd)** are there to help you progress step by step — don’t hesitate to come back to them if you get stuck.
+
+### Translate and understand key concepts
+
+If English slows you down:
+
+- Use [**DeepL**](https://www.deepl.com/translator) to translate explanations or error messages.
+- The **Google Chrome** browser offers **automatic translation of pages**.
+- Do not hesitate to **ask GPT STT-1100 to rephrase or translate** passages.
+
+> The concepts remain the same from one language to another — the important thing is to understand the ideas behind the commands!
+
+## 👩‍🏫 Ask for help effectively
+
+### 🤔 Before asking your question
+
+1. Have you read the entire error message?
+2. Have you tried searching with keywords?
+3. Can you isolate the problem in a simple example?
+
+### 🗣️ Ask a good question (to [GPT STT-1100](https://chatgpt.com/g/g-682d165f32e881918633affa3fe9dfd6-stt-1100), to an assistant or on the forum)
+
+- Be specific: indicate the **minimal** code that causes the error.
+- Copy the **full error message**.
+- Describe what you wanted to do and what is happening.
+
+::: callout-note
+**Example:**
+
+> I wanted to filter the data for penguins with a beak longer than 40mm.\
+> Here is the code:\
+> `penguins %>% filter(bill_length_mm > 40)`\
+> But I get the following error:\
+> `object 'bill_length_mm' not found`
+:::
+
+## 🚨 Don't get stuck alone!
+
+- 📩 **Write to the course forum.**
+- 💬 **Work in pairs or small groups**.
+- 🧑‍🏫 **Come and ask your question in class or to the assistant**.
+- 🤖 **Use GPT STT-1100 wisely**, but check what it responds to you.
+
+## 🎁 Bonus: reflexes to adopt
+
+✅ Find the information for yourself first\
+✅ Document what you learn (personal notes or `.qmd` file)\
+✅ Dare to ask questions!\
+✅ Learn from your mistakes (and those of others)
+
+> 🧠 *The best data scientists are not those who have all the answers... but those who know how to ask the right questions.*
+
+# Overview of data science professions
+
+## Introduction
+
+> *“It takes a village to turn data into value. »*\
+> In this presentation we will discover **who** makes up this village and **how** each role contributes to the cycle of a data science project.
+
+## The cycle of a data science project
+
+![](other_material/Presentation%20of%20different%20roles/whole-game.png){fig-align="center"}
+
+:::notes
+Inspired by Hadley Wickham, *R for Data Science* 2nd ed. (https://r4ds.hadley.nz/whole-game.html).
+:::
+
+- **Import**\
+    Load raw data from their sources into the work environment.
+
+- **Tidy**\
+    Rearrange the data so that one row corresponds to an observation and one column to a variable.
+
+- **Transform**\
+    Filter, aggregate and create new variables to prepare information for analysis.
+
+- **Visualize**\
+    Explore data using graphs to reveal trends, relationships and anomalies.
+
+- **Model**\
+    Build statistical or machine learning models to explain or predict.
+
+- **Communicate**\
+    Present results, limitations and recommendations in a clear and actionable manner to stakeholders.
+
+## Role mapping
+
+| Cycle phase | Key roles | Main objective |
+|------------------------|------------------|------------------------|
+| **Program** (Infrastructure) | *Data Engineer* | Build and maintain data pipelines. |
+| **Import → Store** | *Data Owner* | Hold the data, ensure its quality, security and governance. |
+| **Understand** (Tidy → Transform → Visualize ↔ Model) | *Statistician · Data Scientist · Data Analyst* | Extract knowledge through analyzes and models. |
+| **Communicate** | *Data Journalist · Freelancer* | Tell the data story, popularize it and deliver value to stakeholders. |
+
+## Data Engineer 🛠️
+
+**Mission:** Provide reliable, accessible and well-structured data.
+
+**At work:**\
+- Designs data architectures.\
+- Automates import (`Import`), tidying (`Tidy`) and distribution.\
+- Collaborates closely with the *Data Owner* and prepares the ground for analysts.
+
+::: fragment
+**Cycle connection:** Mainly in the "Program" area and at the beginning of "Understand" (Import → Tidy).
+:::
+
+## Data Owner 🔑
+
+**Mission:** Guarantee governance, compliance and data quality.
+
+**Responsibilities:**\
+- Defines metadata, access and privacy policies.\
+- Validates the source and supervises updates.\
+- Is the legal and organizational point of contact.
+
+**Link to the cycle:** Provides the *raw material* and validates each change before distribution.
+
+## Statistician 📐
+
+**Mission:** Model phenomena and quantify uncertainty.
+
+**At work:**\
+- Chooses the right methods (inference, sampling, experimentation).\
+- Evaluates hypotheses, builds and interprets models.\
+- Guarantees the robustness and validity of the conclusions.
+
+**Link to cycle:** At the heart of `Model`, with a strong loop to `Visualize` to diagnose and explain.
+
+## Data Scientist 🔬
+
+**Mission:** Transform data into high value-added products and recommendations.
+
+**At work:**\
+- Combines programming, statistics and business domain.\
+- Quickly iterates between `Transform`, `Visualize` and `Model`.\
+- Puts solutions into production.
+
+## Data Analyst 📊
+
+**Mission:** Provide operational insights and support day-to-day decision-making.
+
+**At work:**\
+- Prepare reports, performance indexes and dashboards.\
+- Queries the basics, aggregates, creates clear visualizations.\
+- Collaborates with the Data Engineer to ensure data validity.
+
+**Link with the cycle:** Mainly exploits `Transform` and `Visualize`, communicates in the final phase.
+
+## Data Journalist 📰
+
+**Mission:** Tell engaging stories based on verifiable data.
+
+**At work:**\
+- Searches public databases, checks facts.\
+- Creates interactive visualizations and narratives.\
+- Popularizes for a wide audience and defends transparency.
+
+**Link with the cycle:** Emphasizes `Communicate`, draws on the work of other roles for the technical part.
+
+## Freelancer 💼
+
+**Mission:** Provide timely and adaptable expertise over all or part of the cycle.
+
+**Special features:**\
+- Versatility: must understand each role to intervene effectively.\
+- Project management, customer relations and technological monitoring.\
+- Can fill gaps in an internal team.
+
+## Conclusion
+
+- Each role **brings unique expertise** but *none* is enough alone.\
+- **Communication** and **governance** ensure consistency.\
+- In this course, you will put on different hats to experience **the whole cycle**!

--- a/module_01/exercices_corriges.qmd
+++ b/module_01/exercices_corriges.qmd
@@ -7,21 +7,21 @@ editor: visual
 
 ## Quarto
 
-Quarto enables you to weave together content and executable code into a finished document. To learn more about Quarto see <https://quarto.org>.
+Quarto permet de combiner du texte et du code exécutable dans un document final. Pour en savoir plus sur Quarto, consultez <https://quarto.org>.
 
-## Running Code
+## Exécuter du code
 
-When you click the **Render** button a document will be generated that includes both content and the output of embedded code. You can embed code like this:
+Quand vous cliquez sur le bouton **Render**, un document est généré qui contient à la fois le texte et la sortie du code embarqué. Vous pouvez inclure du code ainsi :
 
 ```{r}
 1 + 1
 ```
 
-You can add options to executable code like this
+Vous pouvez ajouter des options à un bloc de code exécutable comme ceci :
 
 ```{r}
 #| echo: false
 2 * 2
 ```
 
-The `echo: false` option disables the printing of code (only output is displayed).
+L'option `echo: false` désactive l'affichage du code (seule la sortie est affichée).

--- a/toggle-sidebar.html
+++ b/toggle-sidebar.html
@@ -1,10 +1,14 @@
 <style>
-  /* États de sidebar */
+  /* Sidebar states */
   body.sidebar-hidden #quarto-sidebar,
   body.sidebar-hidden .quarto-sidebar,
-  body.sidebar-hidden .sidebar { display: none !important; }
+  body.sidebar-hidden .sidebar {
+    display: none !important;
+  }
 
-  body.sidebar-hidden .page-columns { grid-template-columns: minmax(0, 1fr) !important; }
+  body.sidebar-hidden .page-columns {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
   body.sidebar-hidden .page-columns .content {
     grid-column: 1 / -1 !important;
     max-width: 100% !important;
@@ -13,9 +17,10 @@
   body.sidebar-hidden .submenu,
   body.sidebar-hidden .margin-sidebar { display: none !important; }
 
-  /* Évite le chevauchement du logo sur desktop */
+  /* Avoid logo overlap on desktop */
   @media (min-width: 992px) {
     :root { --content-left-offset: 88px; }
+
     body:not(.sidebar-hidden) nav.quarto-page-breadcrumbs,
     body:not(.sidebar-hidden) main#quarto-document-content,
     body:not(.sidebar-hidden) main.content {
@@ -23,142 +28,312 @@
     }
     body.sidebar-hidden nav.quarto-page-breadcrumbs,
     body.sidebar-hidden main#quarto-document-content,
-    body.sidebar-hidden main.content { padding-left: 0 !important; }
+    body.sidebar-hidden main.content {
+      padding-left: 0 !important;
+    }
   }
 
-  /* Style du bouton */
+  .qs-toggle-controls {
+    margin-left: .75rem;
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+  }
+
+  /* Sidebar button styles */
   .qs-toggle-btn{
-    display:inline-flex;align-items:center;gap:.4rem;
-    border:1px solid rgba(0,0,0,.12);border-radius:.5rem;
-    padding:.25rem .5rem;background:var(--quarto-body-bg,#fff);
+    display:inline-flex;
+    align-items:center;
+    gap:.4rem;
+    border:1px solid rgba(0,0,0,.12);
+    border-radius:.5rem;
+    padding:.25rem .5rem;
+    background:var(--quarto-body-bg,#fff);
     box-shadow:0 1px 4px rgba(0,0,0,.08);
-    cursor:pointer;font-size:.95rem; line-height:1;
+    cursor:pointer;
+    font-size:.95rem;
+    line-height:1;
   }
   .qs-toggle-btn:focus{outline:2px solid rgba(0,0,0,.2);outline-offset:2px;}
-  .qs-toggle-container{ margin-left:.75rem; }
 
-  /* On ne masque QUE sur téléphone; tablettes/desktop voient le bouton */
-  @media (max-width: 575.98px){ .qs-toggle-btn{ display:none !important; } }
+  .qs-language-switch{
+    display:inline-flex;
+    align-items:center;
+    gap:.35rem;
+    border:1px solid rgba(0,0,0,.12);
+    border-radius:.5rem;
+    padding:.2rem .35rem;
+    background:var(--quarto-body-bg,#fff);
+    box-shadow:0 1px 4px rgba(0,0,0,.08);
+    font-size:.9rem;
+  }
+
+  .qs-lang-btn{
+    border:none;
+    border-radius:.35rem;
+    background:transparent;
+    color:var(--quarto-body-color,#111);
+    padding:.2rem .45rem;
+    cursor:pointer;
+  }
+  .qs-lang-btn[aria-pressed="true"]{
+    background:rgba(0,0,0,.08);
+    font-weight:700;
+  }
+  .qs-lang-btn:focus{outline:2px solid rgba(0,0,0,.2);outline-offset:2px;}
+
+  .qs-action-group{
+    display:flex;
+    align-items:center;
+    gap:.35rem;
+  }
+
+  /* Hide controls only on phones; tablets/desktops keep them visible */
+  @media (max-width: 575.98px){
+    .qs-toggle-controls{ display:none !important; }
+  }
 </style>
 
 <script>
 (function(){
-  const KEY = 'quarto-sidebar-hidden';
+  const SIDEBAR_KEY = 'quarto-sidebar-hidden';
+  const UI_LABELS = {
+    en: {
+      sidebarTooltip: 'Show/hide left sidebar',
+      sidebarAria: 'Toggle left sidebar',
+      languageAria: 'Language selection'
+    },
+    fr: {
+      sidebarTooltip: 'Masquer/Afficher la barre latérale',
+      sidebarAria: 'Basculer la barre latérale',
+      languageAria: 'Choix de langue'
+    }
+  };
 
-  function applyStateFromStorage(){
-    const hidden = localStorage.getItem(KEY) === '1';
+  function isEnglishPath(pathname){
+    return /(^|\/)en\//.test(pathname);
+  }
+
+  function removeLeadingSlash(path){
+    return path.replace(/^\//, '');
+  }
+
+  function withLeadingSlash(path){
+    return path.startsWith('/') ? path : `/${path}`;
+  }
+
+  function languageTargetUrl(targetLang){
+    const loc = window.location;
+    const path = loc.pathname;
+    const search = loc.search || '';
+    const hash = loc.hash || '';
+
+    if (targetLang === 'en') {
+      if (isEnglishPath(path)) return null;
+      if (path === '/' || path === '') return withLeadingSlash(`en/index.html${search}`) + hash;
+      if (path === '/index.html') return `/en/index.html${search}${hash}`;
+      const noTrail = path.endsWith('/') ? path : path;
+      return withLeadingSlash(`en${noTrail}`) + search + hash;
+    }
+
+    if (targetLang === 'fr') {
+      if (!isEnglishPath(path)) return null;
+      if (path === '/en' || path === '/en/' || path === '/en/index.html') return `/${search ? `${search}${hash}` : hash}`;
+      let withoutEn = path;
+      if (/^\/[^/]+\/en\//.test(path)) {
+        withoutEn = path.replace(/^\/([^/]+)\/en\/(.*)$/, '/$1/$2');
+      } else {
+        withoutEn = path.replace(/^\/en\//, '/');
+      }
+      return withoutEn + search + hash;
+    }
+
+    return null;
+  }
+
+  function uiForPage(){
+    return isEnglishPath(window.location.pathname) ? UI_LABELS.en : UI_LABELS.fr;
+  }
+
+  function applySidebarStateFromStorage(){
+    const hidden = localStorage.getItem(SIDEBAR_KEY) === '1';
     document.body.classList.toggle('sidebar-hidden', hidden);
     const btn = document.getElementById('qs-toggle-btn');
     if (btn) btn.setAttribute('aria-pressed', hidden ? 'true' : 'false');
   }
 
-  function buildButton(){
+  function updateLanguageState(){
+    const isEn = isEnglishPath(window.location.pathname);
+    const fr = document.getElementById('qs-lang-fr');
+    const en = document.getElementById('qs-lang-en');
+    if (fr) fr.setAttribute('aria-pressed', isEn ? 'false' : 'true');
+    if (en) en.setAttribute('aria-pressed', isEn ? 'true' : 'false');
+  }
+
+  function onLanguageClick(targetLang){
+    return (event) => {
+      event.preventDefault();
+      const url = languageTargetUrl(targetLang);
+      if (!url) {
+        updateLanguageState();
+        return;
+      }
+      window.location.href = url;
+    };
+  }
+
+  function buildSidebarButton(){
     const btn = document.createElement('button');
+    const labels = uiForPage();
     btn.id = 'qs-toggle-btn';
     btn.className = 'qs-toggle-btn';
     btn.type = 'button';
-    btn.title = 'Masquer/Afficher le menu de gauche';
-    btn.setAttribute('aria-label','Basculer la barre latérale');
-    btn.setAttribute('aria-pressed','false');
+    btn.title = labels.sidebarTooltip;
+    btn.setAttribute('aria-label', labels.sidebarAria);
+    btn.setAttribute('aria-pressed', 'false');
     btn.innerHTML = `
       <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
         <path d="M3 6h18M3 12h18M3 18h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
       </svg>
       <span>Menu</span>
     `;
-    btn.addEventListener('click', ()=>{
+
+    btn.addEventListener('click', () => {
       document.body.classList.toggle('sidebar-hidden');
       const hidden = document.body.classList.contains('sidebar-hidden');
       btn.setAttribute('aria-pressed', hidden ? 'true' : 'false');
-      try { localStorage.setItem(KEY, hidden ? '1' : '0'); } catch(e){}
+      try {
+        localStorage.setItem(SIDEBAR_KEY, hidden ? '1' : '0');
+      } catch (e) {
+        // ignore
+      }
     });
+
     return btn;
   }
 
-  function insertIntoNavbar(){
+  function buildLanguageSwitch(){
+    const labels = uiForPage();
+    const wrapper = document.createElement('div');
+    wrapper.className = 'qs-language-switch';
+    wrapper.setAttribute('role', 'group');
+    wrapper.setAttribute('aria-label', labels.languageAria);
+
+    const fr = document.createElement('button');
+    fr.type = 'button';
+    fr.id = 'qs-lang-fr';
+    fr.className = 'qs-lang-btn';
+    fr.setAttribute('aria-pressed', 'false');
+    fr.setAttribute('aria-label', 'French version');
+    fr.textContent = 'FR';
+    fr.addEventListener('click', onLanguageClick('fr'));
+
+    const en = document.createElement('button');
+    en.type = 'button';
+    en.id = 'qs-lang-en';
+    en.className = 'qs-lang-btn';
+    en.setAttribute('aria-pressed', 'false');
+    en.setAttribute('aria-label', 'English version');
+    en.textContent = 'EN';
+    en.addEventListener('click', onLanguageClick('en'));
+
+    wrapper.appendChild(fr);
+    wrapper.appendChild(en);
+    return wrapper;
+  }
+
+  function buildActions(){
+    const box = document.createElement('div');
+    box.className = 'qs-toggle-controls';
+    box.appendChild(buildLanguageSwitch());
+    box.appendChild(buildSidebarButton());
+    return box;
+  }
+
+  function insertAfter(selector, node, fallback){
+    const host = document.querySelector(selector);
+    if (host) {
+      const isNav = host.matches('.navbar-nav');
+      if (isNav) {
+        const li = document.createElement('li');
+        li.className = 'nav-item qs-toggle-controls';
+        li.appendChild(node);
+        host.appendChild(li);
+      } else {
+        host.appendChild(node);
+      }
+      return true;
+    }
+
+    if (fallback) {
+      fallback.appendChild(node);
+      return true;
+    }
+    return false;
+  }
+
+  function insertControls(){
     const navbar = document.querySelector('.navbar, .quarto-navbar, #quarto-header .navbar');
-    if (!navbar) return false;
+    const actions = buildActions();
 
-    // Zone à droite si possible
-    let rightZone = navbar.querySelector('.navbar-nav.ms-auto') ||
-                    navbar.querySelector('.navbar-collapse .navbar-nav:last-child');
+    if (navbar) {
+      const rightZone = navbar.querySelector('.navbar-nav.ms-auto') ||
+                        navbar.querySelector('.navbar-collapse .navbar-nav:last-child') ||
+                        navbar.querySelector('.navbar-nav');
 
-    const btn = buildButton();
-
-    if (rightZone && rightZone.matches('.navbar-nav')) {
-      const li = document.createElement('li');
-      li.className = 'nav-item qs-toggle-container';
-      li.appendChild(btn);
-      rightZone.appendChild(li);
-    } else if (rightZone) {
-      const wrap = document.createElement('div');
-      wrap.className = 'qs-toggle-container';
-      wrap.appendChild(btn);
-      rightZone.appendChild(wrap);
-    } else {
-      // Fallback: insérer dans la zone collapse ou directement dans le header
-      const collapse = navbar.querySelector('.navbar-collapse') || navbar;
-      const wrap = document.createElement('div');
-      wrap.className = 'qs-toggle-container';
-      wrap.appendChild(btn);
-      collapse.appendChild(wrap);
+      if (rightZone) {
+        return insertAfter('.navbar-nav.ms-auto', actions, null) || insertAfter('.navbar-collapse .navbar-nav:last-child', actions, null) || insertAfter('.navbar-nav', actions, navbar);
+      }
     }
-    return true;
-  }
 
-  function insertIntoHeader(){
     const header = document.getElementById('quarto-header');
-    if (!header) return false;
-
-    // Crée une petite zone en haut à droite du header
-    let host = header.querySelector('.qs-toggle-host');
-    if (!host) {
-      host = document.createElement('div');
-      host.className = 'qs-toggle-host';
-      host.style.cssText = 'position:absolute; right:12px; top:10px; z-index:1000;';
-      header.style.position = header.style.position || 'relative';
-      header.appendChild(host);
+    if (header) {
+      let host = header.querySelector('.qs-toggle-host');
+      if (!host) {
+        host = document.createElement('div');
+        host.className = 'qs-toggle-host';
+        host.style.cssText = 'position:absolute; right:12px; top:10px; z-index:1000; display:flex; gap:.4rem;';
+        header.style.position = header.style.position || 'relative';
+        header.appendChild(host);
+      }
+      host.innerHTML = '';
+      host.appendChild(actions);
+      return true;
     }
-    host.innerHTML = '';
-    const btn = buildButton();
-    host.appendChild(btn);
-    return true;
-  }
 
-  function ensureButton(){
-    // Essaie d’abord la navbar, sinon le header
-    if (insertIntoNavbar()) return;
-    insertIntoHeader();
+    return false;
   }
 
   function setupResponsiveGuard(){
     const mq = window.matchMedia('(max-width: 575.98px)');
     const handle = () => {
       if (mq.matches) {
-        // Laisse Quarto gérer sur téléphone
         document.body.classList.remove('sidebar-hidden');
       } else {
-        applyStateFromStorage();
+        applySidebarStateFromStorage();
       }
     };
-    mq.addEventListener ? mq.addEventListener('change', handle) : mq.addListener(handle);
+    if (mq.addEventListener) {
+      mq.addEventListener('change', handle);
+    } else {
+      mq.addListener(handle);
+    }
     handle();
   }
 
-  // 1) Au DOM prêt, tente une première insertion
-  document.addEventListener('DOMContentLoaded', ()=>{
-    applyStateFromStorage();
-    ensureButton();
+  document.addEventListener('DOMContentLoaded', () => {
+    applySidebarStateFromStorage();
+    updateLanguageState();
+    insertControls();
     setupResponsiveGuard();
   });
 
-  // 2) Si le header/nav arrive plus tard, observe et insère
-  const obs = new MutationObserver(()=> {
-    if (document.getElementById('qs-toggle-btn')) return;
+  const obs = new MutationObserver(() => {
+    if (document.getElementById('qs-toggle-btn') && document.getElementById('qs-lang-fr')) return;
     if (document.querySelector('.navbar, .quarto-navbar, #quarto-header .navbar, #quarto-header')) {
-      ensureButton();
+      insertControls();
     }
   });
-  obs.observe(document.documentElement, { childList:true, subtree:true });
+  obs.observe(document.documentElement, { childList: true, subtree: true });
 })();
 </script>


### PR DESCRIPTION
## Description

Cette PR ajoute une version anglaise complète du site du cours (structure `en/`) et branche la sélection de langue via le switcher déjà présent dans le template du site.

### Changements principaux

- ✅ Ajout d’un site Quarto anglais complet avec :
  - `en/_quarto.yml`
  - `en/index.qmd`
  - traduction des pages de tous les modules (plans, aventures, défis/exercices selon le cas)
  - `en/references.qmd`
  - `en/projet_session/enonce_projet.qmd`
- ✅ Intégration de la navigation bilingue via `toggle-sidebar.html` (contrôle langue FR/EN).
- ✅ Ajustements/retouches de qualité sur fichiers existants pour garantir que la version anglaise soit cohérente et exécutable :
  - `module_01/exercices_corriges.qmd`
  - `en/module_02/plan_apprentissage.qmd`
  - corrections ponctuelles dans `en/module_02/aventure.qmd`, `en/module_03/aventure.qmd`, `en/module_05/aventure.qmd` (notamment guillemets typographiques/robustesse du code).

### Objectif

Permettre une publication en ligne d’un site bilingue (FR / EN), avec accès direct à la section anglaise sous `/en/`.

### Remarque

Le déploiement GitHub Pages dépend de la configuration du dépôt (branche source/page cible).  
La branche `feat/bilingual-switch` est prête pour preview (prévisualisation PR) ; la publication automatique dépend de la config Pages côté dépôt.
